### PR TITLE
fix: handle unstable manualSnapToPoint variable when re-rendering

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -30,7 +30,6 @@ import {
   State,
 } from 'react-native-gesture-handler';
 import {
-  useValue,
   usePanGestureHandler,
   useTapGestureHandler,
   // ReText,
@@ -186,12 +185,15 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       state: tapGestureState,
       gestureHandler: tapGestureHandler,
     } = useTapGestureHandler();
-
-    const autoSnapTo = useValue<number>(-1);
     //#endregion
 
     //#region animation
-    const { position, currentPosition, currentGesture } = useTransition({
+    const {
+      position,
+      manualSnapToPoint,
+      currentPosition,
+      currentGesture,
+    } = useTransition({
       animationDuration,
       animationEasing,
       contentPanGestureState,
@@ -200,7 +202,6 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       handlePanGestureState,
       handlePanGestureTranslationY,
       handlePanGestureVelocityY,
-      autoSnapTo,
       scrollableContentOffsetY,
       snapPoints,
       initialPosition,
@@ -277,21 +278,21 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
             snapPoints.length - 1
           }`
         );
-        autoSnapTo.setValue(snapPoints[index]);
+        manualSnapToPoint.setValue(snapPoints[index]);
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [snapPoints]
     );
     const handleClose = useCallback(() => {
-      autoSnapTo.setValue(sheetHeight);
+      manualSnapToPoint.setValue(sheetHeight);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [sheetHeight]);
     const handleExpand = useCallback(() => {
-      autoSnapTo.setValue(snapPoints[snapPoints.length - 1]);
+      manualSnapToPoint.setValue(snapPoints[snapPoints.length - 1]);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [sheetHeight]);
     const handleCollapse = useCallback(() => {
-      autoSnapTo.setValue(snapPoints[0]);
+      manualSnapToPoint.setValue(snapPoints[0]);
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [sheetHeight]);
     //#endregion

--- a/src/components/bottomSheet/useTransition.ts
+++ b/src/components/bottomSheet/useTransition.ts
@@ -33,7 +33,6 @@ interface TransitionProps extends Required<BottomSheetAnimationConfigs> {
   handlePanGestureTranslationY: Animated.Value<number>;
   handlePanGestureVelocityY: Animated.Value<number>;
 
-  autoSnapTo: Animated.Value<number>;
   scrollableContentOffsetY: Animated.Value<number>;
   snapPoints: number[];
   initialPosition: number;
@@ -48,7 +47,6 @@ export const useTransition = ({
   handlePanGestureState,
   handlePanGestureTranslationY,
   handlePanGestureVelocityY,
-  autoSnapTo,
   scrollableContentOffsetY,
   snapPoints,
   initialPosition,
@@ -60,6 +58,7 @@ export const useTransition = ({
   const isPanningHandle = eq(handlePanGestureState, State.ACTIVE);
   const isPanning = or(isPanningContent, isPanningHandle);
   const shouldAnimate = useValue(0);
+  const manualSnapToPoint = useValue<number>(-1);
 
   const clock = useClock();
   const config = useMemo(
@@ -113,7 +112,7 @@ export const useTransition = ({
   );
   const isAnimationInterrupted = and(
     clockRunning(clock),
-    or(isPanning, neq(autoSnapTo, -1))
+    or(isPanning, neq(manualSnapToPoint, -1))
   );
   const position = block([
     // debug('current gesture', currentGesture),
@@ -182,14 +181,12 @@ export const useTransition = ({
     /**
      * Manual snapping node.
      */
-    onChange(autoSnapTo, [
-      cond(neq(autoSnapTo, -1), [
-        // debug('Manually snap to', autoSnapTo),
-        set(config.toValue, autoSnapTo),
-        set(autoSnapTo, -1),
-        set(animationState.finished, 0),
-        set(shouldAnimate, 1),
-      ]),
+    cond(neq(manualSnapToPoint, -1), [
+      // debug('Manually snap to', manualSnapToPoint),
+      set(config.toValue, manualSnapToPoint),
+      set(animationState.finished, 0),
+      set(shouldAnimate, 1),
+      set(manualSnapToPoint, -1),
     ]),
 
     /**
@@ -212,6 +209,7 @@ export const useTransition = ({
 
   return {
     position,
+    manualSnapToPoint,
     currentPosition,
     currentGesture,
   };


### PR DESCRIPTION
closes (#29)