### PR TITLE
feat: Add possibility to disable tap handler

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -85,6 +85,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       // components
       handleComponent: HandleComponent = Handle,
       backgroundComponent: BackgroundComponent = null,
+      disableTapGestureHandler = false,
       children,
     },
     ref
@@ -397,6 +398,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           ref={rootTapGestureRef}
           initialMaxDeltaY={snapPoints[Math.max(initialSnapIndex, 0)]}
           style={containerStyle}
+          disableTapGestureHandler={disableTapGestureHandler}
           {...tapGestureHandler}
         >
           <Animated.View style={contentContainerStyle}>

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -61,6 +61,11 @@ export interface BottomSheetProps extends BottomSheetAnimationConfigs {
    * @type React.ReactNode[] | React.ReactNode
    */
   children: React.ReactNode[] | React.ReactNode;
+  /**
+   * Whether to disable tap gesture handler
+   * @type boolean | undefined
+   */
+  disableTapGestureHandler?: boolean;
 }
 
 export interface BottomSheetAnimationConfigs {

--- a/src/components/contentWrapper/ContentWrapper.android.tsx
+++ b/src/components/contentWrapper/ContentWrapper.android.tsx
@@ -8,7 +8,7 @@ const ContentWrapperComponent = forwardRef<
   BottomSheetContentWrapperProps
 >(
   (
-    { children, initialMaxDeltaY, onGestureEvent, onHandlerStateChange },
+    { children, initialMaxDeltaY, onGestureEvent, onHandlerStateChange, disableTapGestureHandler },
     ref
   ) => {
     return (
@@ -19,6 +19,7 @@ const ContentWrapperComponent = forwardRef<
         shouldCancelWhenOutside={false}
         onGestureEvent={onGestureEvent}
         onHandlerStateChange={onHandlerStateChange}
+        enabled={!disableTapGestureHandler}
       >
         {children}
       </TapGestureHandler>

--- a/src/components/contentWrapper/ContentWrapper.ios.tsx
+++ b/src/components/contentWrapper/ContentWrapper.ios.tsx
@@ -9,7 +9,7 @@ const ContentWrapperComponent = forwardRef<
   BottomSheetContentWrapperProps
 >(
   (
-    { children, initialMaxDeltaY, style, onGestureEvent, onHandlerStateChange },
+    { children, initialMaxDeltaY, style, onGestureEvent, onHandlerStateChange, disableTapGestureHandler },
     ref
   ) => {
     return (
@@ -20,6 +20,7 @@ const ContentWrapperComponent = forwardRef<
         shouldCancelWhenOutside={false}
         onGestureEvent={onGestureEvent}
         onHandlerStateChange={onHandlerStateChange}
+        enabled={!disableTapGestureHandler}
       >
         <Animated.View pointerEvents="box-none" style={style}>
           {children}

--- a/src/components/contentWrapper/types.d.ts
+++ b/src/components/contentWrapper/types.d.ts
@@ -8,6 +8,7 @@ export type BottomSheetContentWrapperProps = {
   style: StyleProp<ViewStyle>;
   onHandlerStateChange: (...args: any[]) => void;
   onGestureEvent: (...args: any[]) => void;
+  disableTapGestureHandler: boolean;
 };
 
 export type BottomSheetContentWrapper = React.ForwardRefExoticComponent<


### PR DESCRIPTION
## Motivation
While quite impressed by the performance of this module, I've added it to my project just to discover problem with react-native touchables (especially on android)
this PR adds possibility to disable the ContentWrapper TapGestureHandler in order to make the react-native touchables work

