### PR TITLE
feat: allow control panning gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,11 @@ npm install @gorhom/bottom-sheet
 
 > ⚠️ You need to install [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) & [react-native-gesture-handler](https://github.com/software-mansion/react-native-gesture-handler) and follow their installation instructions.
 
-
 ### Version v2 ( Alpha )
 
 [Link to version 2 branch](https://github.com/gorhom/react-native-bottom-sheet/tree/feature/rewrite-in-reanimated-v2)
 
 this version is written with `Reanimated v2`, although this version is still in alpha phase, yet it provides all version 1 functionalities with the huge performance boost, thanks to `Reanimated v2` ❤️
-
 
 ```sh
 yarn add @gorhom/bottom-sheet@2.0.0-alpha.0
@@ -143,9 +141,15 @@ Top inset value helps to calculate percentage snap points values. usually comes 
 
 > `required:` NO | `type:` number | `default:` 0
 
-#### `enabled`
+#### `enableContentPanningGesture`
 
-To enable or disable user interaction with the sheet.
+Enable content panning gesture interaction.
+
+> `required:` NO | `type:` boolean | `default:` true
+
+#### `enableHandlePanningGesture`
+
+Enable handle panning gesture interaction.
 
 > `required:` NO | `type:` boolean | `default:` true
 

--- a/example/src/screens/advanced/CustomHandleExample.tsx
+++ b/example/src/screens/advanced/CustomHandleExample.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import BottomSheet from '@gorhom/bottom-sheet';
 import Handle from '../../components/handle';
@@ -6,17 +6,11 @@ import Button from '../../components/button';
 import ContactList from '../../components/contactList';
 
 const CustomHandleExample = () => {
-  // state
-  const [enabled, setEnabled] = useState(true);
-
   // hooks
   const bottomSheetRef = useRef<BottomSheet>(null);
 
   // variables
   const snapPoints = useMemo(() => [150, 300, 450], []);
-  const enableButtonText = useMemo(() => (enabled ? 'Disable' : 'Enable'), [
-    enabled,
-  ]);
 
   // callbacks
   const handleSnapPress = useCallback(index => {
@@ -30,9 +24,6 @@ const CustomHandleExample = () => {
   }, []);
   const handleClosePress = useCallback(() => {
     bottomSheetRef.current?.close();
-  }, []);
-  const handleEnablePress = useCallback(() => {
-    setEnabled(state => !state);
   }, []);
 
   // renders
@@ -76,14 +67,8 @@ const CustomHandleExample = () => {
         style={styles.buttonContainer}
         onPress={handleClosePress}
       />
-      <Button
-        label={enableButtonText}
-        style={styles.buttonContainer}
-        onPress={handleEnablePress}
-      />
       <BottomSheet
         ref={bottomSheetRef}
-        enabled={enabled}
         snapPoints={snapPoints}
         initialSnapIndex={1}
         handleComponent={Handle}

--- a/example/src/screens/advanced/NavigatorExample.tsx
+++ b/example/src/screens/advanced/NavigatorExample.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { View, StyleSheet } from 'react-native';
 import {
   createStackNavigator,
@@ -69,17 +69,11 @@ const Navigator = () => {
 };
 
 const NavigatorExample = () => {
-  // state
-  const [enabled, setEnabled] = useState(true);
-
   // hooks
   const bottomSheetRef = useRef<BottomSheet>(null);
 
   // variables
   const snapPoints = useMemo(() => ['25%', '50%', '90%'], []);
-  const enableButtonText = useMemo(() => (enabled ? 'Disable' : 'Enable'), [
-    enabled,
-  ]);
 
   // callbacks
   const handleSheetChange = useCallback(index => {
@@ -96,9 +90,6 @@ const NavigatorExample = () => {
   }, []);
   const handleClosePress = useCallback(() => {
     bottomSheetRef.current?.close();
-  }, []);
-  const handleEnablePress = useCallback(() => {
-    setEnabled(state => !state);
   }, []);
 
   // renders
@@ -134,14 +125,8 @@ const NavigatorExample = () => {
         style={styles.buttonContainer}
         onPress={handleClosePress}
       />
-      <Button
-        label={enableButtonText}
-        style={styles.buttonContainer}
-        onPress={handleEnablePress}
-      />
       <BottomSheet
         ref={bottomSheetRef}
-        enabled={enabled}
         snapPoints={snapPoints}
         initialSnapIndex={1}
         onChange={handleSheetChange}

--- a/example/src/screens/static/BasicExample.tsx
+++ b/example/src/screens/static/BasicExample.tsx
@@ -9,7 +9,6 @@ import { useSafeArea } from 'react-native-safe-area-context';
 
 const BasicExample = () => {
   // state
-  const [enabled, setEnabled] = useState(true);
   const [dynamicSnapPoint, setDynamicSnapPoint] = useState(450);
 
   // hooks
@@ -61,16 +60,9 @@ const BasicExample = () => {
         style={styles.buttonContainer}
         onPress={() => handleClosePress()}
       />
-
-      <Button
-        label={`${enabled ? 'Disable' : 'Enable'}`}
-        style={styles.buttonContainer}
-        onPress={() => setEnabled(state => !state)}
-      />
       <ReText text={concat('Position from bottom: ', position)} />
       <BottomSheet
         ref={bottomSheetRef}
-        enabled={enabled}
         snapPoints={snapPoints}
         initialSnapIndex={1}
         topInset={topSafeArea}

--- a/example/src/screens/static/BasicExamples.tsx
+++ b/example/src/screens/static/BasicExamples.tsx
@@ -13,16 +13,34 @@ interface ExampleScreenProps {
 const createExampleScreen = ({ type, count = 20 }: ExampleScreenProps) =>
   memo(() => {
     // state
-    const [enabled, setEnabled] = useState(true);
+    const [
+      enableContentPanningGesture,
+      setEnableContentPanningGesture,
+    ] = useState(true);
+    const [
+      enableHandlePanningGesture,
+      setEnableHandlePanningGesture,
+    ] = useState(true);
 
     // hooks
     const bottomSheetRef = useRef<BottomSheet>(null);
 
     // variables
     const snapPoints = useMemo(() => ['25%', '50%', '90%'], []);
-    const enableButtonText = useMemo(() => (enabled ? 'Disable' : 'Enable'), [
-      enabled,
-    ]);
+    const enableContentPanningGestureButtonText = useMemo(
+      () =>
+        enableContentPanningGesture
+          ? 'Disable Content Panning Gesture'
+          : 'Enable Content Panning Gesture',
+      [enableContentPanningGesture]
+    );
+    const enableHandlePanningGestureButtonText = useMemo(
+      () =>
+        enableHandlePanningGesture
+          ? 'Disable Handle Panning Gesture'
+          : 'Enable Handle Panning Gesture',
+      [enableHandlePanningGesture]
+    );
 
     // callbacks
     const handleSheetChange = useCallback(index => {
@@ -40,8 +58,11 @@ const createExampleScreen = ({ type, count = 20 }: ExampleScreenProps) =>
     const handleClosePress = useCallback(() => {
       bottomSheetRef.current?.close();
     }, []);
-    const handleEnablePress = useCallback(() => {
-      setEnabled(state => !state);
+    const handleEnableContentPanningGesturePress = useCallback(() => {
+      setEnableContentPanningGesture(state => !state);
+    }, []);
+    const handleEnableHandlePanningGesturePress = useCallback(() => {
+      setEnableHandlePanningGesture(state => !state);
     }, []);
 
     return (
@@ -77,16 +98,22 @@ const createExampleScreen = ({ type, count = 20 }: ExampleScreenProps) =>
           onPress={handleClosePress}
         />
         <Button
-          label={enableButtonText}
+          label={enableContentPanningGestureButtonText}
           style={styles.buttonContainer}
-          onPress={handleEnablePress}
+          onPress={handleEnableContentPanningGesturePress}
+        />
+        <Button
+          label={enableHandlePanningGestureButtonText}
+          style={styles.buttonContainer}
+          onPress={handleEnableHandlePanningGesturePress}
         />
         <BottomSheet
           ref={bottomSheetRef}
-          enabled={enabled}
           snapPoints={snapPoints}
           initialSnapIndex={1}
           animateOnMount={true}
+          enableContentPanningGesture={enableContentPanningGesture}
+          enableHandlePanningGesture={enableHandlePanningGesture}
           onChange={handleSheetChange}
         >
           <ContactList key={`${type}.list`} type={type} count={count} />

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -52,6 +52,8 @@ import {
   DEFAULT_ANIMATION_EASING,
   DEFAULT_ANIMATION_DURATION,
   DEFAULT_HANDLE_HEIGHT,
+  DEFAULT_ENABLE_CONTENT_PANNING_GESTURE,
+  DEFAULT_ENABLE_HANDLE_PANNING_GESTURE,
 } from './constants';
 import type { ScrollableRef, BottomSheetMethods } from '../../types';
 import type { BottomSheetProps } from './types';
@@ -78,10 +80,11 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       // configurations
       initialSnapIndex = 0,
       snapPoints: _snapPoints,
-      topInset = 0,
-      enabled = true,
-      animateOnMount = DEFAULT_ANIMATE_ON_MOUNT,
       handleHeight: _handleHeight,
+      topInset = 0,
+      enableContentPanningGesture = DEFAULT_ENABLE_CONTENT_PANNING_GESTURE,
+      enableHandlePanningGesture = DEFAULT_ENABLE_HANDLE_PANNING_GESTURE,
+      animateOnMount = DEFAULT_ANIMATE_ON_MOUNT,
       // container props
       containerHeight,
       containerTapGestureRef,
@@ -327,7 +330,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     //#region context variables
     const internalContextVariables = useMemo(
       () => ({
-        enabled,
+        enableContentPanningGesture,
         containerTapGestureRef,
         handlePanGestureState,
         handlePanGestureTranslationY,
@@ -340,8 +343,20 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         setScrollableRef: handleSettingScrollableRef,
         removeScrollableRef,
       }),
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [enabled]
+      [
+        enableContentPanningGesture,
+        containerTapGestureRef,
+        contentPanGestureState,
+        contentPanGestureTranslationY,
+        contentPanGestureVelocityY,
+        handlePanGestureState,
+        handlePanGestureTranslationY,
+        handlePanGestureVelocityY,
+        decelerationRate,
+        scrollableContentOffsetY,
+        handleSettingScrollableRef,
+        removeScrollableRef,
+      ]
     );
     const externalContextVariables = useMemo(
       () => ({
@@ -451,25 +466,13 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         ),
       [HandleComponent, animatedPositionIndex]
     );
-    // console.log(
-    //   'BottomSheet \t\t',
-    //   'render',
-    //   'containerHeight: ',
-    //   containerHeight,
-    //   'handleHeight: ',
-    //   handleHeight,
-    //   'sheetHeight: ',
-    //   sheetHeight,
-    //   'snapPoints: ',
-    //   snapPoints
-    // );
     return (
       <>
         <Animated.View style={sheetContainerStyle}>
           {renderBackground()}
           <BottomSheetProvider value={externalContextVariables}>
             <PanGestureHandler
-              enabled={enabled}
+              enabled={enableHandlePanningGesture}
               ref={handlePanGestureRef}
               simultaneousHandlers={containerTapGestureRef}
               shouldCancelWhenOutside={false}

--- a/src/components/bottomSheet/constants.ts
+++ b/src/components/bottomSheet/constants.ts
@@ -7,16 +7,27 @@ const {
 } = require('react-native-reanimated');
 const Easing = EasingV2 || EasingV1;
 
-export const DEFAULT_ANIMATION_EASING: Animated.EasingFunction = Easing.out(
+// defaults
+const DEFAULT_ANIMATION_EASING: Animated.EasingFunction = Easing.out(
   Easing.back(0.75)
 );
-export const DEFAULT_ANIMATION_DURATION = 500;
+const DEFAULT_ANIMATION_DURATION = 500;
+const DEFAULT_ANIMATE_ON_MOUNT = false;
+const DEFAULT_HANDLE_HEIGHT = 24;
+const DEFAULT_ENABLE_CONTENT_PANNING_GESTURE = true;
+const DEFAULT_ENABLE_HANDLE_PANNING_GESTURE = true;
 
-export const NORMAL_DECELERATION_RATE = Platform.select({
+const NORMAL_DECELERATION_RATE = Platform.select({
   ios: 0.998,
   android: 0.985,
 });
 
-export const DEFAULT_ANIMATE_ON_MOUNT = false;
-
-export const DEFAULT_HANDLE_HEIGHT = 24;
+export {
+  DEFAULT_ANIMATION_EASING,
+  DEFAULT_ANIMATION_DURATION,
+  DEFAULT_ANIMATE_ON_MOUNT,
+  DEFAULT_HANDLE_HEIGHT,
+  DEFAULT_ENABLE_CONTENT_PANNING_GESTURE,
+  DEFAULT_ENABLE_HANDLE_PANNING_GESTURE,
+  NORMAL_DECELERATION_RATE,
+};

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -27,11 +27,17 @@ export type BottomSheetProps = {
    */
   topInset?: number;
   /**
-   * To enable or disable user interaction with the sheet.
+   * Enable content panning gesture interaction.
    * @type boolean
    * @default true
    */
-  enabled?: boolean;
+  enableContentPanningGesture?: boolean;
+  /**
+   * Enable handle panning gesture interaction.
+   * @type boolean
+   * @default true
+   */
+  enableHandlePanningGesture?: boolean;
   /**
    * To start the sheet closed and snap to initial index when it's mounted.
    * @type boolean

--- a/src/components/draggableView/DraggableView.tsx
+++ b/src/components/draggableView/DraggableView.tsx
@@ -18,7 +18,7 @@ const BottomSheetDraggableViewComponent = ({
 
   // hooks
   const {
-    enabled,
+    enableContentPanningGesture,
     containerTapGestureRef,
     handlePanGestureState,
     handlePanGestureTranslationY,
@@ -73,7 +73,7 @@ const BottomSheetDraggableViewComponent = ({
   return (
     <PanGestureHandler
       ref={panGestureRef}
-      enabled={enabled}
+      enabled={enableContentPanningGesture}
       simultaneousHandlers={simultaneousHandlers}
       shouldCancelWhenOutside={false}
       onGestureEvent={handleGestureEvent}

--- a/src/components/flatList/FlatList.tsx
+++ b/src/components/flatList/FlatList.tsx
@@ -44,7 +44,7 @@ const BottomSheetFlatListComponent = forwardRef(
       handleSettingScrollable,
     } = useScrollableInternal('FlatList');
     const {
-      enabled,
+      enableContentPanningGesture,
       containerTapGestureRef,
       decelerationRate,
     } = useBottomSheetInternal();
@@ -63,7 +63,7 @@ const BottomSheetFlatListComponent = forwardRef(
       >
         <NativeViewGestureHandler
           ref={nativeGestureRef}
-          enabled={enabled}
+          enabled={enableContentPanningGesture}
           waitFor={containerTapGestureRef}
         >
           <AnimatedFlatList

--- a/src/components/scrollView/ScrollView.tsx
+++ b/src/components/scrollView/ScrollView.tsx
@@ -44,7 +44,7 @@ const BottomSheetScrollViewComponent = forwardRef(
       handleSettingScrollable,
     } = useScrollableInternal('ScrollView');
     const {
-      enabled,
+      enableContentPanningGesture,
       containerTapGestureRef,
       decelerationRate,
     } = useBottomSheetInternal();
@@ -62,7 +62,7 @@ const BottomSheetScrollViewComponent = forwardRef(
       >
         <NativeViewGestureHandler
           ref={nativeGestureRef}
-          enabled={enabled}
+          enabled={enableContentPanningGesture}
           waitFor={containerTapGestureRef}
         >
           <AnimatedScrollView

--- a/src/components/sectionList/SectionList.tsx
+++ b/src/components/sectionList/SectionList.tsx
@@ -44,7 +44,7 @@ const BottomSheetSectionListComponent = forwardRef(
       handleSettingScrollable,
     } = useScrollableInternal('SectionList');
     const {
-      enabled,
+      enableContentPanningGesture,
       containerTapGestureRef,
       decelerationRate,
     } = useBottomSheetInternal();
@@ -62,7 +62,7 @@ const BottomSheetSectionListComponent = forwardRef(
       >
         <NativeViewGestureHandler
           ref={nativeGestureRef}
-          enabled={enabled}
+          enabled={enableContentPanningGesture}
           waitFor={containerTapGestureRef}
         >
           <AnimatedSectionList

--- a/src/contexts/internal.ts
+++ b/src/contexts/internal.ts
@@ -4,7 +4,7 @@ import type Animated from 'react-native-reanimated';
 import { Scrollable, ScrollableRef } from '../types';
 
 export type BottomSheetInternalContextType = {
-  enabled: boolean;
+  enableContentPanningGesture: boolean;
   containerTapGestureRef: Ref<TapGestureHandler>;
   contentPanGestureState: Animated.Value<State>;
   contentPanGestureTranslationY: Animated.Value<number>;


### PR DESCRIPTION
closes #55 

## Motivation

This will allow user to control panning gesture interaction with `content` and `handle`.

this is part of [v2 Roadmap](https://github.com/gorhom/react-native-bottom-sheet/issues/75).