### PR TITLE
fix: fixed animatedIndex interpolate node to handle one snap point

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -260,14 +260,21 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     const animatedIndex = useMemo(
       () =>
         interpolate(position, {
-          inputRange: snapPoints.slice().reverse(),
-          outputRange: snapPoints
-            .slice()
-            .map((_, index) => index)
-            .reverse(),
+          /**
+           * this been added to resolve issues when provide
+           * one snap point.
+           */
+          inputRange: [...snapPoints.slice().reverse(), containerHeight],
+          outputRange: [
+            ...snapPoints
+              .slice()
+              .map((_, index) => index)
+              .reverse(),
+            -1,
+          ],
           extrapolate: Extrapolate.CLAMP,
         }),
-      [position, snapPoints]
+      [position, containerHeight, snapPoints]
     );
 
     const animatedPosition = useMemo(

--- a/src/components/bottomSheet/useTransition.ts
+++ b/src/components/bottomSheet/useTransition.ts
@@ -271,7 +271,7 @@ export const useTransition = ({
                   call(
                     [config.toValue, ...snapPoints],
                     ([_toValue, ..._animatedSnapPoints]) => {
-                      const currentIndex = currentIndexRef.current || -1;
+                      const currentIndex = currentIndexRef.current!;
                       const nextIndex = _animatedSnapPoints.indexOf(_toValue);
 
                       if (onAnimate) {


### PR DESCRIPTION
closes #50 

## Motivation

this will allow the sheet to accept one snap point and not block the content intractability
