### PR TITLE
Fix for setting 0 handle height

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -123,7 +123,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     // safe layout values
 
     const safeHandleHeight = useMemo(
-      () => handleHeight || DEFAULT_HANDLE_HEIGHT,
+      () => handleHeight ?? DEFAULT_HANDLE_HEIGHT,
       [handleHeight]
     );
     const safeContainerHeight = useMemo(() => containerHeight || windowHeight, [


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

The new handle height causes a gap at the bottom of the sheet when not rendering a handle.

