### PR TITLE
feat: added over scroll and bouncing support

### DIFF
--- a/example/src/components/contactItem/ContactItem.tsx
+++ b/example/src/components/contactItem/ContactItem.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 import { TouchableOpacity } from '@gorhom/bottom-sheet';
 
@@ -13,16 +13,20 @@ const ContactItemComponent = ({
   subTitle,
   onPress,
 }: ContactItemProps) => {
+  const ContentWrapper = useMemo<any>(
+    () => (onPress ? TouchableOpacity : View),
+    [onPress]
+  );
   // render
   return (
-    <TouchableOpacity onPress={onPress} style={styles.container}>
+    <ContentWrapper onPress={onPress} style={styles.container}>
       <View style={styles.thumbnail} />
       <View style={styles.contentContainer}>
         <Text style={styles.title}>{title}</Text>
         {subTitle && <Text style={styles.subtitle}>{subTitle}</Text>}
       </View>
       <View style={styles.icon} />
-    </TouchableOpacity>
+    </ContentWrapper>
   );
 };
 

--- a/example/src/components/contactList/ContactList.tsx
+++ b/example/src/components/contactList/ContactList.tsx
@@ -98,6 +98,7 @@ const ContactList = ({
         data={data}
         keyExtractor={keyExtractor}
         initialNumToRender={5}
+        bounces={true}
         windowSize={10}
         maxToRenderPerBatch={5}
         renderItem={renderFlatListItem}
@@ -113,6 +114,7 @@ const ContactList = ({
     return (
       <BottomSheetScrollView
         contentContainerStyle={contentContainerStyle}
+        bounces={true}
         focusHook={useFocusEffect}
       >
         {header && header()}
@@ -127,6 +129,7 @@ const ContactList = ({
         initialNumToRender={5}
         windowSize={10}
         maxToRenderPerBatch={5}
+        bounces={true}
         sections={sections}
         keyExtractor={keyExtractor}
         renderSectionHeader={renderSectionHeader}

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -531,13 +531,13 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     //#endregion
 
     // render
-    console.log(
-      'BottomSheet',
-      'render',
-      snapPoints,
-      safeContainerHeight,
-      safeHandleHeight
-    );
+    // console.log(
+    //   'BottomSheet',
+    //   'render',
+    //   snapPoints,
+    //   safeContainerHeight,
+    //   safeHandleHeight
+    // );
     return (
       <BottomSheetProvider value={externalContextVariables}>
         <BottomSheetBackdropContainer

--- a/src/components/flatList/FlatList.tsx
+++ b/src/components/flatList/FlatList.tsx
@@ -66,13 +66,13 @@ const BottomSheetFlatListComponent = forwardRef(
           ref={nativeGestureRef}
           enabled={enableContentPanningGesture}
           waitFor={contentWrapperGestureRef}
+          shouldCancelWhenOutside={false}
         >
           <AnimatedFlatList
             {...rest}
             // @ts-ignore
             ref={scrollableRef}
-            overScrollMode="never"
-            bounces={false}
+            overScrollMode="always"
             scrollEventThrottle={1}
             onScrollBeginDrag={handleScrollEvent}
             // @ts-ignore

--- a/src/components/flatList/types.d.ts
+++ b/src/components/flatList/types.d.ts
@@ -4,7 +4,6 @@ import type { FlatListProps as RNFlatListProps } from 'react-native';
 type BottomSheetFlatListProps<T> = Omit<
   RNFlatListProps<T>,
   | 'overScrollMode'
-  | 'bounces'
   | 'decelerationRate'
   | 'onScrollBeginDrag'
   | 'scrollEventThrottle'

--- a/src/components/scrollView/ScrollView.tsx
+++ b/src/components/scrollView/ScrollView.tsx
@@ -65,12 +65,12 @@ const BottomSheetScrollViewComponent = forwardRef(
           ref={nativeGestureRef}
           enabled={enableContentPanningGesture}
           waitFor={contentWrapperGestureRef}
+          shouldCancelWhenOutside={false}
         >
           <AnimatedScrollView
             {...rest}
             ref={scrollableRef}
-            overScrollMode="never"
-            bounces={false}
+            overScrollMode="always"
             scrollEventThrottle={1}
             onScrollBeginDrag={handleScrollEvent}
             // @ts-ignore

--- a/src/components/scrollView/types.d.ts
+++ b/src/components/scrollView/types.d.ts
@@ -7,7 +7,6 @@ import type {
 export type BottomSheetScrollViewProps = Omit<
   RNScrollViewProps,
   | 'overScrollMode'
-  | 'bounces'
   | 'decelerationRate'
   | 'onScrollBeginDrag'
   | 'scrollEventThrottle'
@@ -22,9 +21,7 @@ export type BottomSheetScrollViewProps = Omit<
 
 type Constructor<T> = new (...args: any[]) => T;
 
-declare class BottomSheetScrollViewComponent extends Component<
-  BottomSheetScrollViewProps
-> {}
+declare class BottomSheetScrollViewComponent extends Component<BottomSheetScrollViewProps> {}
 declare const BottomSheetScrollViewBase: Constructor<ScrollResponderMixin> &
   typeof BottomSheetScrollViewComponent;
 

--- a/src/components/sectionList/SectionList.tsx
+++ b/src/components/sectionList/SectionList.tsx
@@ -66,13 +66,13 @@ const BottomSheetSectionListComponent = forwardRef(
           ref={nativeGestureRef}
           enabled={enableContentPanningGesture}
           waitFor={contentWrapperGestureRef}
+          shouldCancelWhenOutside={false}
         >
           <AnimatedSectionList
             {...rest}
             // @ts-ignore
             ref={scrollableRef}
-            overScrollMode="never"
-            bounces={false}
+            overScrollMode="always"
             scrollEventThrottle={1}
             onScrollBeginDrag={handleScrollEvent}
             // @ts-ignore

--- a/src/components/sectionList/types.d.ts
+++ b/src/components/sectionList/types.d.ts
@@ -4,7 +4,6 @@ import type { SectionListProps as RNSectionListProps } from 'react-native';
 type BottomSheetSectionListProps<T> = Omit<
   RNSectionListProps<T>,
   | 'overScrollMode'
-  | 'bounces'
   | 'decelerationRate'
   | 'onScrollBeginDrag'
   | 'scrollEventThrottle'


### PR DESCRIPTION
closes #136 

## Motivation

- allow user to set `bounces` prop on Scrollables.
- set `overScrollMode` to `always` by default. 
