### PR TITLE
fix: remove jumping on Android while starting scrolling

### DIFF
--- a/src/hooks/useScrollableInternal.ts
+++ b/src/hooks/useScrollableInternal.ts
@@ -16,6 +16,7 @@ export const useScrollableInternal = (type: ScrollableType) => {
   const scrollableRef = useAnimatedRef<Scrollable>();
   const scrollablePosition = useSharedValue<number>(0);
   const scrollableContentOffsetY = useSharedValue<number>(0);
+  const justStartedScrolling = useSharedValue<number>(0);
 
   // hooks
   const {
@@ -36,6 +37,7 @@ export const useScrollableInternal = (type: ScrollableType) => {
   const handleScrollEvent = useAnimatedScrollHandler({
     onBeginDrag: ({ contentOffset: { y } }: NativeScrollEvent) => {
       if (animatedIndex.value !== snapPointsCount - 1) {
+        justStartedScrolling.value = 1;
         scrollablePosition.value = 0;
         scrollableContentOffsetY.value = 0;
         _rootScrollableContentOffsetY.value = 0;
@@ -46,6 +48,12 @@ export const useScrollableInternal = (type: ScrollableType) => {
       _rootScrollableContentOffsetY.value = y;
     },
     onScroll: ({ contentOffset: { y } }: NativeScrollEvent) => {
+      if (justStartedScrolling.value === 1) {
+        justStartedScrolling.value = 0;
+        // @ts-ignore
+        scrollTo(scrollableRef, 0, 0, false);
+        return;
+      }
       if (animatedIndex.value !== snapPointsCount - 1) {
         // @ts-ignore
         scrollTo(scrollableRef, 0, scrollablePosition.value, false);

--- a/src/hooks/useScrollableInternal.ts
+++ b/src/hooks/useScrollableInternal.ts
@@ -17,6 +17,7 @@ export const useScrollableInternal = (type: ScrollableType) => {
   const scrollablePosition = useSharedValue<number>(0);
   const scrollableContentOffsetY = useSharedValue<number>(0);
   const justStartedScrolling = useSharedValue<number>(0);
+  const initialScrollingPosition = useSharedValue<number>(0);
 
   // hooks
   const {
@@ -37,6 +38,7 @@ export const useScrollableInternal = (type: ScrollableType) => {
   const handleScrollEvent = useAnimatedScrollHandler({
     onBeginDrag: ({ contentOffset: { y } }: NativeScrollEvent) => {
       if (animatedIndex.value !== snapPointsCount - 1) {
+        initialScrollingPosition.value = y;
         justStartedScrolling.value = 1;
         scrollablePosition.value = 0;
         scrollableContentOffsetY.value = 0;
@@ -51,7 +53,7 @@ export const useScrollableInternal = (type: ScrollableType) => {
       if (justStartedScrolling.value === 1) {
         justStartedScrolling.value = 0;
         // @ts-ignore
-        scrollTo(scrollableRef, 0, 0, false);
+        scrollTo(scrollableRef, 0, initialScrollingPosition.value, false);
         return;
       }
       if (animatedIndex.value !== snapPointsCount - 1) {


### PR DESCRIPTION


## Motivation

I observed that while initial scrolling content sometimes "jumps" from 0 to some non-linear value e.g. 20.

I noticed that the native event emits scroll position 0 and then immediately 20 or so on - probably it relates to the velocity of the movement. 

Hence, I added a tweak to ensure that content is initially not scrolled more than initially