### PR TITLE
refactor: updated overScrollMode to be come overridable

### DIFF
--- a/src/components/flatList/FlatList.tsx
+++ b/src/components/flatList/FlatList.tsx
@@ -34,7 +34,11 @@ const BottomSheetFlatListName = 'FlatList';
 const BottomSheetFlatListComponent = forwardRef(
   (props: BottomSheetFlatListProps<any>, ref: Ref<RNFlatList>) => {
     // props
-    const { focusHook: useFocusHook = useEffect, ...rest } = props;
+    const {
+      focusHook: useFocusHook = useEffect,
+      overScrollMode = 'never',
+      ...rest
+    } = props;
 
     // refs
     const nativeGestureRef = useRef<NativeViewGestureHandler>(null);
@@ -72,7 +76,7 @@ const BottomSheetFlatListComponent = forwardRef(
             {...rest}
             // @ts-ignore
             ref={scrollableRef}
-            overScrollMode="always"
+            overScrollMode={overScrollMode}
             scrollEventThrottle={16}
             onScrollBeginDrag={handleScrollEvent}
             // @ts-ignore

--- a/src/components/flatList/types.d.ts
+++ b/src/components/flatList/types.d.ts
@@ -3,10 +3,7 @@ import type { FlatListProps as RNFlatListProps } from 'react-native';
 
 type BottomSheetFlatListProps<T> = Omit<
   RNFlatListProps<T>,
-  | 'overScrollMode'
-  | 'decelerationRate'
-  | 'onScrollBeginDrag'
-  | 'scrollEventThrottle'
+  'decelerationRate' | 'onScrollBeginDrag' | 'scrollEventThrottle'
 > & {
   /**
    * This needed when bottom sheet used with multiple scrollables to allow bottom sheet detect the current scrollable ref, especially when used with `React Navigation`. You will need to provide `useFocusEffect` from `@react-navigation/native`.

--- a/src/components/scrollView/ScrollView.tsx
+++ b/src/components/scrollView/ScrollView.tsx
@@ -34,7 +34,11 @@ const BottomSheetScrollViewName = 'ScrollView';
 const BottomSheetScrollViewComponent = forwardRef(
   (props: BottomSheetScrollViewProps, ref: Ref<RNScrollView>) => {
     // props
-    const { focusHook: useFocusHook = useEffect, ...rest } = props;
+    const {
+      focusHook: useFocusHook = useEffect,
+      overScrollMode = 'never',
+      ...rest
+    } = props;
 
     // refs
     const nativeGestureRef = useRef<NativeViewGestureHandler>(null);
@@ -70,7 +74,7 @@ const BottomSheetScrollViewComponent = forwardRef(
           <AnimatedScrollView
             {...rest}
             ref={scrollableRef}
-            overScrollMode="always"
+            overScrollMode={overScrollMode}
             scrollEventThrottle={16}
             onScrollBeginDrag={handleScrollEvent}
             // @ts-ignore

--- a/src/components/scrollView/types.d.ts
+++ b/src/components/scrollView/types.d.ts
@@ -6,10 +6,7 @@ import type {
 
 export type BottomSheetScrollViewProps = Omit<
   RNScrollViewProps,
-  | 'overScrollMode'
-  | 'decelerationRate'
-  | 'onScrollBeginDrag'
-  | 'scrollEventThrottle'
+  'decelerationRate' | 'onScrollBeginDrag' | 'scrollEventThrottle'
 > & {
   children: React.ReactNode[] | React.ReactNode;
   /**

--- a/src/components/sectionList/SectionList.tsx
+++ b/src/components/sectionList/SectionList.tsx
@@ -34,7 +34,11 @@ const BottomSheetSectionListName = 'SectionList';
 const BottomSheetSectionListComponent = forwardRef(
   (props: BottomSheetSectionListProps<any>, ref: Ref<RNSectionList>) => {
     // props
-    const { focusHook: useFocusHook = useEffect, ...rest } = props;
+    const {
+      focusHook: useFocusHook = useEffect,
+      overScrollMode = 'never',
+      ...rest
+    } = props;
 
     // refs
     const nativeGestureRef = useRef<NativeViewGestureHandler>(null);
@@ -72,7 +76,7 @@ const BottomSheetSectionListComponent = forwardRef(
             {...rest}
             // @ts-ignore
             ref={scrollableRef}
-            overScrollMode="always"
+            overScrollMode={overScrollMode}
             scrollEventThrottle={16}
             onScrollBeginDrag={handleScrollEvent}
             // @ts-ignore

--- a/src/components/sectionList/types.d.ts
+++ b/src/components/sectionList/types.d.ts
@@ -3,10 +3,7 @@ import type { SectionListProps as RNSectionListProps } from 'react-native';
 
 type BottomSheetSectionListProps<T> = Omit<
   RNSectionListProps<T>,
-  | 'overScrollMode'
-  | 'decelerationRate'
-  | 'onScrollBeginDrag'
-  | 'scrollEventThrottle'
+  'decelerationRate' | 'onScrollBeginDrag' | 'scrollEventThrottle'
 > & {
   /**
    * This needed when bottom sheet used with multiple scrollables to allow bottom sheet detect the current scrollable ref, especially when used with `React Navigation`. You will need to provide `useFocusEffect` from `@react-navigation/native`.


### PR DESCRIPTION
## Motivation

setting `overScrollMode` to `always` was causing the Material ripple effect to appears on Android, However setting it to `never` did not impact on the scrolling over at all.

- `overScrollMode` now is overridable by user.
- `overScrollMode` default value is set to `never`.