### PR TITLE
refactor: remove getNode from scrollables refs

### DIFF
--- a/src/components/flatList/FlatList.tsx
+++ b/src/components/flatList/FlatList.tsx
@@ -54,7 +54,7 @@ const BottomSheetFlatListComponent = forwardRef(
 
     // effects
     // @ts-ignore
-    useImperativeHandle(ref, () => scrollableRef.current!.getNode());
+    useImperativeHandle(ref, () => scrollableRef.current);
     useFocusHook(handleSettingScrollable);
 
     // render

--- a/src/components/scrollView/ScrollView.tsx
+++ b/src/components/scrollView/ScrollView.tsx
@@ -54,7 +54,7 @@ const BottomSheetScrollViewComponent = forwardRef(
 
     // effects
     // @ts-ignore
-    useImperativeHandle(ref, () => scrollableRef.current!);
+    useImperativeHandle(ref, () => scrollableRef.current);
     useFocusHook(handleSettingScrollable);
 
     return (

--- a/src/components/sectionList/SectionList.tsx
+++ b/src/components/sectionList/SectionList.tsx
@@ -54,7 +54,7 @@ const BottomSheetSectionListComponent = forwardRef(
 
     // effects
     // @ts-ignore
-    useImperativeHandle(ref, () => scrollableRef.current!.getNode());
+    useImperativeHandle(ref, () => scrollableRef.current);
     useFocusHook(handleSettingScrollable);
 
     // render


### PR DESCRIPTION
closes #162 

## Motivation

- removed `getNode` from scrollables refs.