### PR TITLE
fix: removed rounding up from useNormalizedSnapPoints hook.

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -358,7 +358,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       (index: number) => {
         invariant(
           index >= -1 && index <= snapPoints.length - 1,
-          `'index' was provided but out of the provided snap points range! expected value to be between -1, ${snapPoints.length - 1}`
+          `'index' was provided but out of the provided snap points range! expected value to be between -1, ${
+            snapPoints.length - 1
+          }`
         );
         runOnUI(animateToPoint)(snapPoints[index]);
       },
@@ -565,11 +567,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         _contentGestureState,
         _handleGestureState,
       }) => {
-
-        const tempCurrentPositionIndex = Math.round(_animatedIndex);
-
         if (
-          tempCurrentPositionIndex % 1 === 0 &&
+          _animatedIndex % 1 === 0 &&
           _animationState === ANIMATION_STATE.STOPPED &&
           (_contentGestureState === State.END ||
             _contentGestureState === State.UNDETERMINED) &&

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -358,9 +358,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       (index: number) => {
         invariant(
           index >= -1 && index <= snapPoints.length - 1,
-          `'index' was provided but out of the provided snap points range! expected value to be between -1, ${
-            snapPoints.length - 1
-          }`
+          `'index' was provided but out of the provided snap points range! expected value to be between -1, ${snapPoints.length - 1}`
         );
         runOnUI(animateToPoint)(snapPoints[index]);
       },
@@ -567,8 +565,11 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         _contentGestureState,
         _handleGestureState,
       }) => {
+
+        const tempCurrentPositionIndex = Math.round(_animatedIndex);
+
         if (
-          _animatedIndex % 1 === 0 &&
+          tempCurrentPositionIndex % 1 === 0 &&
           _animationState === ANIMATION_STATE.STOPPED &&
           (_contentGestureState === State.END ||
             _contentGestureState === State.UNDETERMINED) &&

--- a/src/hooks/useNormalizedSnapPoints.ts
+++ b/src/hooks/useNormalizedSnapPoints.ts
@@ -21,8 +21,9 @@ export const useNormalizedSnapPoints = (
       if (normalizedSnapPoint === 0 && handleHeight !== 0) {
         normalizedSnapPoint = normalizedSnapPoint - handleHeight;
       }
-      return Math.ceil(
-        Math.max(containerHeight - normalizedSnapPoint - handleHeight, topInset)
+      return Math.max(
+        containerHeight - normalizedSnapPoint - handleHeight,
+        topInset
       );
     });
   }, [snapPoints, topInset, containerHeight, handleHeight]);


### PR DESCRIPTION
went ahead and fixed the cause of the modal not showing after the first dismiss.

`_animatedIndex ` was resulting in a decimal number causing `_animatedIndex % 1 === 0` to be false and never triggering `runOnJS(handleOnChange)`
This caused the index to be stuck at 1 and did not trigger the `doDismiss` function in `BottomSheetModal`

