### PR TITLE
Update docs

### DIFF
--- a/website/docs/modal/hooks.md
+++ b/website/docs/modal/hooks.md
@@ -12,10 +12,10 @@ This hook provides modal functionalities only, for sheet functionalities please 
 > This hook works at any component in `BottomSheetModalProvider`.
 
 ```tsx
-import { useBottomSheet} from '@gorhom/bottom-sheet';
+import { useBottomSheetModal } from '@gorhom/bottom-sheet';
 
 const SheetContent = () => {
-  const { dismiss, dismissAll } = useBottomSheet();
+  const { dismiss, dismissAll } = useBottomSheetModal();
 
   return (
     <View>

--- a/website/docs/modal/usage.md
+++ b/website/docs/modal/usage.md
@@ -9,12 +9,11 @@ Here is a simple usage of the **Bottom Sheet Modal**, with non-scrollable conten
 
 ```tsx
 import React, { useCallback, useMemo, useRef } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Button } from 'react-native';
 import {
   BottomSheetModal,
   BottomSheetModalProvider,
 } from '@gorhom/bottom-sheet';
-import { Button } from 'react-native';
 
 const App = () => {
   // ref


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

The modal hooks page is using the regular bottom sheet hook in its example which does not include `dismiss` and `dismissAll`

The modal Usage page imports from `react-native` twice. combined to clean up