### PR TITLE
fix: updated gesture handler to sets all gesture states

### DIFF
--- a/src/hooks/useInteractivePanGestureHandler.ts
+++ b/src/hooks/useInteractivePanGestureHandler.ts
@@ -118,6 +118,15 @@ export const useInteractivePanGestureHandler = (
 
         animateToPoint(destinationPoint, gestureVelocityY.value / 2);
       },
+      onCancel: ({ state }) => {
+        gestureState.value = state;
+      },
+      onFail: ({ state }) => {
+        gestureState.value = state;
+      },
+      onFinish: ({ state }) => {
+        gestureState.value = state;
+      },
     },
     [snapPoints, enableOverDrag, overDragResistanceFactor]
   );


### PR DESCRIPTION
closes #171 

## Motivation

currently the gesture handler does not handle `onCancel`, `onFail` & `onFinish`, and they have been added with this pr/