### PR TITLE
fix: exp easing flickers on android

### DIFF
--- a/src/components/bottomSheet/constants.ts
+++ b/src/components/bottomSheet/constants.ts
@@ -1,9 +1,9 @@
 import { Platform } from 'react-native';
 import Animated, { Easing } from 'react-native-reanimated';
+import { exp } from '../../utilities/easingExp';
 
-const DEFAULT_ANIMATION_EASING: Animated.EasingFunction = Easing.out(
-  Easing.cubic
-);
+const DEFAULT_ANIMATION_EASING: Animated.EasingFunction = Easing.out(exp);
+
 const DEFAULT_ANIMATION_DURATION = 500;
 const DEFAULT_HANDLE_HEIGHT = 24;
 const DEFAULT_OVER_DRAG_RESISTANCE_FACTOR = 2.5;

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -146,7 +146,7 @@ export interface BottomSheetAnimationConfigs {
   /**
    * Snapping animation easing function.
    * @type Animated.EasingFunction
-   * @default Easing.out(Easing.cubic)
+   * @default Easing.out(Easing.exp)
    * @deprecated this prop will be dropped in the next major release.
    * @see animationConfigs
    */

--- a/src/hooks/useBottomSheetTimingConfigs.ts
+++ b/src/hooks/useBottomSheetTimingConfigs.ts
@@ -1,15 +1,42 @@
+import { useMemo } from 'react';
 import Animated, {
   useWorkletCallback,
   withTiming,
 } from 'react-native-reanimated';
+import {
+  DEFAULT_ANIMATION_DURATION,
+  DEFAULT_ANIMATION_EASING,
+} from '../components/bottomSheet/constants';
 
+/**
+ * Generate animation timing configs.
+ * @default
+ * - easing: Easing.out(Easing.exp)
+ * - duration 500
+ * @param configs overridable configs.
+ */
 export const useBottomSheetTimingConfigs = (
   configs: Animated.WithTimingConfig
 ) => {
+  const overrideConfigs = useMemo(() => {
+    const _configs: Animated.WithTimingConfig = {
+      easing: DEFAULT_ANIMATION_EASING,
+      duration: DEFAULT_ANIMATION_DURATION,
+    };
+
+    if (configs.easing) {
+      _configs.easing = configs.easing;
+    }
+
+    if (configs.duration) {
+      _configs.duration = configs.duration;
+    }
+    return _configs;
+  }, [configs.duration, configs.easing]);
   const animationConfig = useWorkletCallback(
     (point: number, _, callback: () => void) =>
-      withTiming(point, configs, callback),
-    [configs]
+      withTiming(point, overrideConfigs, callback),
+    [overrideConfigs]
   );
   return animationConfig;
 };

--- a/src/utilities/easingExp.ts
+++ b/src/utilities/easingExp.ts
@@ -1,0 +1,10 @@
+/**
+ * A modified version of the default AnimatedEasing.exp,
+ * to insure its value never goes below `0`.
+ * @see https://github.com/software-mansion/react-native-reanimated/issues/1610
+ * @param t number
+ */
+export const exp = (t: number) => {
+  'worklet';
+  return Math.min(Math.max(0, Math.pow(2, 10 * (t - 1))), 1);
+};


### PR DESCRIPTION
## Motivation

the issue was already reported to `react-native-reanimated` repo https://github.com/software-mansion/react-native-reanimated/issues/1610

this pr introduce a modified version of exp method that insures the return value never go below `0`.
