### PR TITLE
fix: prevent start animation when sheet is closing

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -162,6 +162,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
 
     // refs
     const currentIndexRef = useRef<number>(_providedIndex);
+    const isClosing = useRef(false);
     const didMountOnAnimate = useRef(false);
 
     const {
@@ -319,6 +320,10 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       if (_providedOnChange) {
         _providedOnChange(index);
       }
+
+      if (isClosing.current && (index === 0 || index === -1)) {
+        isClosing.current = false;
+      }
     });
     const handleSettingScrollableRef = useCallback(
       (scrollableRef: ScrollableRef) => {
@@ -338,17 +343,27 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
             snapPoints.length - 1
           }`
         );
+        if (isClosing.current) {
+          return;
+        }
         manualSnapToPoint.setValue(snapPoints[index]);
       },
       [snapPoints, manualSnapToPoint]
     );
     const handleClose = useCallback(() => {
+      isClosing.current = true;
       manualSnapToPoint.setValue(safeContainerHeight);
     }, [manualSnapToPoint, safeContainerHeight]);
     const handleExpand = useCallback(() => {
+      if (isClosing.current) {
+        return;
+      }
       manualSnapToPoint.setValue(snapPoints[snapPoints.length - 1]);
     }, [snapPoints, manualSnapToPoint]);
     const handleCollapse = useCallback(() => {
+      if (isClosing.current) {
+        return;
+      }
       manualSnapToPoint.setValue(snapPoints[0]);
     }, [snapPoints, manualSnapToPoint]);
     //#endregion

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -468,7 +468,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       if (
         animateOnMount &&
         isLayoutCalculated &&
-        didMountOnAnimate.current === false
+        didMountOnAnimate.current === false &&
+        isClosing.current === false
       ) {
         manualSnapToPoint.setValue(snapPoints[_providedIndex]);
         didMountOnAnimate.current = true;
@@ -485,7 +486,11 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
      * keep animated position synced with snap points.
      */
     useEffect(() => {
-      if (isLayoutCalculated && currentIndexRef.current !== -1) {
+      if (
+        isLayoutCalculated &&
+        currentIndexRef.current !== -1 &&
+        isClosing.current === false
+      ) {
         manualSnapToPoint.setValue(snapPoints[currentIndexRef.current]);
       }
     }, [isLayoutCalculated, snapPoints, manualSnapToPoint]);

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -336,14 +336,14 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
 
     //#region public methods
     const handleSnapTo = useCallback(
-      (index: number) => {
+      (index: number, force: boolean = false) => {
         invariant(
           index >= 0 && index <= snapPoints.length - 1,
           `'index' was provided but out of the provided snap points range! expected value to be between -1, ${
             snapPoints.length - 1
           }`
         );
-        if (isClosing.current) {
+        if (isClosing.current && !force) {
           return;
         }
         manualSnapToPoint.setValue(snapPoints[index]);

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -338,7 +338,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     const handleSnapTo = useCallback(
       (index: number) => {
         invariant(
-          index >= -1 && index <= snapPoints.length - 1,
+          index >= 0 && index <= snapPoints.length - 1,
           `'index' was provided but out of the provided snap points range! expected value to be between -1, ${
             snapPoints.length - 1
           }`

--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -54,6 +54,7 @@ const BottomSheetModalComponent = forwardRef<
   const isMinimized = useRef(false);
   const isForcedDismissed = useRef(false);
   const currentIndexRef = useRef(-1);
+  const nextIndexRef = useRef(-1);
   //#endregion
 
   //#region variables
@@ -62,6 +63,7 @@ const BottomSheetModalComponent = forwardRef<
     () => (dismissOnPanDown ? _providedIndex + 1 : _providedIndex),
     [_providedIndex, dismissOnPanDown]
   );
+  nextIndexRef.current = index;
   const snapPoints = useMemo(
     () =>
       dismissOnPanDown ? [0, ..._providedSnapPoints] : _providedSnapPoints,
@@ -89,6 +91,7 @@ const BottomSheetModalComponent = forwardRef<
 
       const adjustedIndex = dismissOnPanDown ? _index - 1 : _index;
       currentIndexRef.current = _index;
+      nextIndexRef.current = _index;
 
       if (adjustedIndex >= 0) {
         if (_providedOnChange) {
@@ -112,7 +115,7 @@ const BottomSheetModalComponent = forwardRef<
   const handleRestore = useCallback(() => {
     if (isMinimized.current) {
       isMinimized.current = false;
-      bottomSheetRef.current?.snapTo(currentIndexRef.current);
+      bottomSheetRef.current?.snapTo(nextIndexRef.current);
     }
   }, []);
   //#endregion
@@ -144,29 +147,29 @@ const BottomSheetModalComponent = forwardRef<
     if (isMinimized.current) {
       return;
     }
+    nextIndexRef.current = 0;
     bottomSheetRef.current?.close();
   }, []);
   const handleCollapse = useCallback(() => {
     if (isMinimized.current) {
       return;
     }
-    if (dismissOnPanDown) {
-      bottomSheetRef.current?.snapTo(1);
-    } else {
-      bottomSheetRef.current?.collapse();
-    }
+    nextIndexRef.current = dismissOnPanDown ? 1 : 0;
+    bottomSheetRef.current?.snapTo(dismissOnPanDown ? 1 : 0);
   }, [dismissOnPanDown]);
   const handleExpand = useCallback(() => {
     if (isMinimized.current) {
       return;
     }
+    nextIndexRef.current = snapPoints.length - 1;
     bottomSheetRef.current?.expand();
-  }, []);
+  }, [snapPoints]);
   const handleSnapTo = useCallback(
     (_index: number) => {
       if (isMinimized.current) {
         return;
       }
+      nextIndexRef.current = _index + (dismissOnPanDown ? 1 : 0);
       bottomSheetRef.current?.snapTo(_index + (dismissOnPanDown ? 1 : 0));
     },
     [dismissOnPanDown]

--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -115,7 +115,7 @@ const BottomSheetModalComponent = forwardRef<
   const handleRestore = useCallback(() => {
     if (isMinimized.current) {
       isMinimized.current = false;
-      bottomSheetRef.current?.snapTo(nextIndexRef.current);
+      bottomSheetRef.current?.snapTo(nextIndexRef.current, true);
     }
   }, []);
   //#endregion

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,7 +6,7 @@ export interface BottomSheetMethods {
    * Snap to one of the provided points from `snapPoints`.
    * @type (index: number) => void
    */
-  snapTo: (index: number) => void;
+  snapTo: (index: number, force?: boolean) => void;
   /**
    * Snap to the maximum provided point from `snapPoints`.
    * @type () => void


### PR DESCRIPTION
closes #204 

## Motivation

this should solve the issue caused when sheet is closing and something else trigger snapping.

## Installation 

```bash
yarn add ssh://git@github.com:gorhom/react-native-bottom-sheet#fix/prevent-snapping-when-closing
```