### PR TITLE
fix: fixed sheet visibility when handle provided null

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -125,8 +125,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
 
     // safe layout values
     const safeHandleHeight = useMemo(
-      () => handleHeight || DEFAULT_HANDLE_HEIGHT,
-      [handleHeight]
+      () =>
+        handleComponent === null ? 0 : handleHeight || DEFAULT_HANDLE_HEIGHT,
+      [handleHeight, handleComponent]
     );
     const safeContainerHeight = useMemo(
       () => _providedContainerHeight || containerHeight || WINDOW_HEIGHT,
@@ -140,7 +141,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     );
     const shouldMeasureHandleHeight = useMemo(
       () =>
-        _providedHandleHeight === undefined && handleComponent !== undefined,
+        _providedHandleHeight === undefined &&
+        handleComponent !== undefined &&
+        handleComponent !== null,
       [_providedHandleHeight, handleComponent]
     );
 
@@ -590,7 +593,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     //   'render',
     //   snapPoints,
     //   safeContainerHeight,
-    //   safeHandleHeight
+    //   safeHandleHeight,
+    //   isLayoutCalculated
     // );
     return (
       <BottomSheetProvider value={externalContextVariables}>


### PR DESCRIPTION
closes #217 

## Motivation

the issue was `shouldMeasureHandleHeight` marked `true` when `handleComponent` is null.