### PR TITLE
fix: fixed sheet visibility when handle provided null

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -124,8 +124,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     // safe layout values
 
     const safeHandleHeight = useMemo(
-      () => handleHeight || DEFAULT_HANDLE_HEIGHT,
-      [handleHeight]
+      () =>
+        handleComponent === null ? 0 : handleHeight || DEFAULT_HANDLE_HEIGHT,
+      [handleHeight, handleComponent]
     );
     const safeContainerHeight = useMemo(
       () => _providedContainerHeight || containerHeight || WINDOW_HEIGHT,
@@ -139,7 +140,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     );
     const shouldMeasureHandleHeight = useMemo(
       () =>
-        _providedHandleHeight === undefined && handleComponent !== undefined,
+        _providedHandleHeight === undefined &&
+        handleComponent !== undefined &&
+        handleComponent !== null,
       [_providedHandleHeight, handleComponent]
     );
 


### PR DESCRIPTION
closes #217 

## Motivation

the issue was `shouldMeasureHandleHeight` marked `true` when `handleComponent` is null.
