### PR TITLE
fix: stabilise animated callback node variables

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -262,16 +262,25 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         adjustedSnapPointsIndexes.push(-1);
       }
 
-      return interpolate(position, {
-        inputRange: adjustedSnapPoints,
-        outputRange: adjustedSnapPointsIndexes,
-        extrapolate: Extrapolate.CLAMP,
-      });
-    }, [position, safeContainerHeight, snapPoints]);
+      return cond(
+        animatedIsLayoutReady,
+        interpolate(position, {
+          inputRange: adjustedSnapPoints,
+          outputRange: adjustedSnapPointsIndexes,
+          extrapolate: Extrapolate.CLAMP,
+        }),
+        0
+      );
+    }, [position, animatedIsLayoutReady, safeContainerHeight, snapPoints]);
 
     const animatedPosition = useMemo(
-      () => abs(sub(safeContainerHeight, position)),
-      [safeContainerHeight, position]
+      () =>
+        cond(
+          animatedIsLayoutReady,
+          abs(sub(safeContainerHeight, position)),
+          safeContainerHeight
+        ),
+      [safeContainerHeight, position, animatedIsLayoutReady]
     );
 
     /**


### PR DESCRIPTION
close #208 

## Motivation

with this pr, `animatedIndex` and `animatedPosition` won't be interpolated until the layout is calculated.

## Installation

```bash
yarn add ssh://git@github.com:gorhom/react-native-bottom-sheet#fix/animated-variables-flickering
```
