### PR TITLE
fix: prevent modal crash when navigating

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -9,7 +9,7 @@
     "start": "react-native start"
   },
   "dependencies": {
-    "@gorhom/portal": "^0.1.4",
+    "@gorhom/portal": "^0.2.0",
     "@gorhom/showcase-template": "^1.0.2",
     "@react-native-community/blur": "^3.6.0",
     "@react-native-community/masked-view": "0.1.10",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -818,10 +818,10 @@
   dependencies:
     "@types/hammerjs" "^2.0.36"
 
-"@gorhom/portal@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@gorhom/portal/-/portal-0.1.4.tgz#ef9e50d4b6c98ebe606a16d22d6cb58d661421b4"
-  integrity sha512-iU3D0i9NureT5ULTvD8moF2FWyFvVGcr/ahcRMDzBblUO1AwwixZRZ+Lf3d6uk0w4ujOQZ7+Az+uUnI+AsXXBw==
+"@gorhom/portal@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@gorhom/portal/-/portal-0.2.0.tgz#65423726b1352e2b9e3c3b8da83a58e4dff48ce6"
+  integrity sha512-PoYYSliPCl624ORih+zyI1pVbH2Y2Mj+EY6nXeAIi2r1LGv10hItZLzdgnbPPfQ0neikTDYArlOzuB5zKIex5w==
   dependencies:
     lodash.isequal "^4.5.0"
     nanoid "^3.1.20"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "bootstrap": "yarn install && yarn example"
   },
   "dependencies": {
-    "@gorhom/portal": "^0.1.4",
+    "@gorhom/portal": "^0.2.0",
     "invariant": "^2.2.4",
     "lodash.isequal": "^4.5.0",
     "nanoid": "^3.1.20",

--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -43,7 +43,7 @@ const BottomSheetModalComponent = forwardRef<
   //#endregion
 
   //#region hooks
-  const { unmount } = usePortal();
+  const { unmount: unmountPortal } = usePortal();
   const {
     containerHeight,
     mountSheet,
@@ -58,7 +58,6 @@ const BottomSheetModalComponent = forwardRef<
   const isForcedDismissed = useRef(false);
   const currentIndexRef = useRef(-1);
   const nextIndexRef = useRef(-1);
-  const unmounted = useRef(false);
   //#endregion
 
   //#region variables
@@ -82,17 +81,14 @@ const BottomSheetModalComponent = forwardRef<
     }
 
     unmountSheet(key);
+    unmountPortal(key);
 
-    if (unmounted.current) {
-      unmount(key);
-      return;
-    }
     setMount(false);
 
     // reset
     isMinimized.current = false;
     isForcedDismissed.current = false;
-  }, [key, _providedOnDismiss, unmountSheet, unmount]);
+  }, [key, _providedOnDismiss, unmountSheet, unmountPortal]);
   const handleOnChange = useCallback(
     (_index: number) => {
       if (isMinimized.current && !isForcedDismissed.current) {
@@ -185,7 +181,6 @@ const BottomSheetModalComponent = forwardRef<
     }
   }, []);
   const handleOnUnmount = useCallback(() => {
-    unmounted.current = true;
     handleDismiss(true);
   }, [handleDismiss]);
   //#endregion

--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -7,7 +7,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Portal } from '@gorhom/portal';
+import { Portal, usePortal } from '@gorhom/portal';
 import { nanoid } from 'nanoid/non-secure';
 import isEqual from 'lodash.isequal';
 import BottomSheet from '../bottomSheet';
@@ -42,12 +42,15 @@ const BottomSheetModalComponent = forwardRef<
   const [mount, setMount] = useState(false);
   //#endregion
 
+  //#region hooks
+  const { unmount } = usePortal();
   const {
     containerHeight,
     mountSheet,
     unmountSheet,
     willUnmountSheet,
   } = useBottomSheetModalInternal();
+  //#endregion
 
   //#region refs
   const bottomSheetRef = useRef<BottomSheet>(null);
@@ -55,6 +58,7 @@ const BottomSheetModalComponent = forwardRef<
   const isForcedDismissed = useRef(false);
   const currentIndexRef = useRef(-1);
   const nextIndexRef = useRef(-1);
+  const unmounted = useRef(false);
   //#endregion
 
   //#region variables
@@ -76,13 +80,19 @@ const BottomSheetModalComponent = forwardRef<
     if (_providedOnDismiss) {
       _providedOnDismiss();
     }
-    setMount(false);
+
     unmountSheet(key);
+
+    if (unmounted.current) {
+      unmount(key);
+      return;
+    }
+    setMount(false);
 
     // reset
     isMinimized.current = false;
     isForcedDismissed.current = false;
-  }, [key, _providedOnDismiss, unmountSheet]);
+  }, [key, _providedOnDismiss, unmountSheet, unmount]);
   const handleOnChange = useCallback(
     (_index: number) => {
       if (isMinimized.current && !isForcedDismissed.current) {
@@ -103,21 +113,6 @@ const BottomSheetModalComponent = forwardRef<
     },
     [dismissOnPanDown, _providedOnChange, doDismiss]
   );
-  //#endregion
-
-  //#region private methods
-  const handleMinimize = useCallback(() => {
-    if (!isMinimized.current) {
-      isMinimized.current = true;
-      bottomSheetRef.current?.close();
-    }
-  }, []);
-  const handleRestore = useCallback(() => {
-    if (isMinimized.current) {
-      isMinimized.current = false;
-      bottomSheetRef.current?.snapTo(nextIndexRef.current, true);
-    }
-  }, []);
   //#endregion
 
   //#region public methods
@@ -176,6 +171,25 @@ const BottomSheetModalComponent = forwardRef<
   );
   //#endregion
 
+  //#region private methods
+  const handleMinimize = useCallback(() => {
+    if (!isMinimized.current) {
+      isMinimized.current = true;
+      bottomSheetRef.current?.close();
+    }
+  }, []);
+  const handleRestore = useCallback(() => {
+    if (isMinimized.current) {
+      isMinimized.current = false;
+      bottomSheetRef.current?.snapTo(nextIndexRef.current, true);
+    }
+  }, []);
+  const handleOnUnmount = useCallback(() => {
+    unmounted.current = true;
+    handleDismiss(true);
+  }, [handleDismiss]);
+  //#endregion
+
   //#region expose public methods
   useImperativeHandle(ref, () => ({
     present: handlePresent,
@@ -192,7 +206,7 @@ const BottomSheetModalComponent = forwardRef<
 
   // render
   return mount ? (
-    <Portal key={key} name={key}>
+    <Portal key={key} name={key} handleOnUnmount={handleOnUnmount}>
       <BottomSheet
         {...bottomSheetProps}
         ref={bottomSheetRef}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1181,10 +1181,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@gorhom/portal@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@gorhom/portal/-/portal-0.1.4.tgz#ef9e50d4b6c98ebe606a16d22d6cb58d661421b4"
-  integrity sha512-iU3D0i9NureT5ULTvD8moF2FWyFvVGcr/ahcRMDzBblUO1AwwixZRZ+Lf3d6uk0w4ujOQZ7+Az+uUnI+AsXXBw==
+"@gorhom/portal@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@gorhom/portal/-/portal-0.2.0.tgz#65423726b1352e2b9e3c3b8da83a58e4dff48ce6"
+  integrity sha512-PoYYSliPCl624ORih+zyI1pVbH2Y2Mj+EY6nXeAIi2r1LGv10hItZLzdgnbPPfQ0neikTDYArlOzuB5zKIex5w==
   dependencies:
     lodash.isequal "^4.5.0"
     nanoid "^3.1.20"


### PR DESCRIPTION
close #240 

## Motivation

to provide better handling when unmounting due to navigation change.


https://user-images.githubusercontent.com/4061838/106208485-c1a0f400-61c3-11eb-9265-46e299501578.mp4

## Installation 

```bash
yarn add ssh://git@github.com:gorhom/react-native-bottom-sheet#fix/prevent-modal-crash-when-navigating
```