### PR TITLE
fix: prevent crash when resizing container height on Android

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -366,7 +366,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
             snapPoints.length - 1
           }`
         );
-        runOnUI(animateToPoint)(snapPoints[index]);
+        const newSnapPoint = snapPoints[index];
+        runOnUI(animateToPoint)(newSnapPoint);
       },
       [animateToPoint, snapPoints]
     );
@@ -374,10 +375,12 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       runOnUI(animateToPoint)(safeContainerHeight);
     }, [animateToPoint, safeContainerHeight]);
     const handleExpand = useCallback(() => {
-      runOnUI(animateToPoint)(snapPoints[snapPoints.length - 1]);
+      const newSnapPoint = snapPoints[snapPoints.length - 1];
+      runOnUI(animateToPoint)(newSnapPoint);
     }, [animateToPoint, snapPoints]);
     const handleCollapse = useCallback(() => {
-      runOnUI(animateToPoint)(snapPoints[0]);
+      const newSnapPoint = snapPoints[0];
+      runOnUI(animateToPoint)(newSnapPoint);
     }, [animateToPoint, snapPoints]);
     useImperativeHandle(ref, () => ({
       snapTo: handleSnapTo,
@@ -488,9 +491,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         didMountOnAnimate.current === false &&
         snapPoints[_providedIndex] !== safeContainerHeight
       ) {
-        requestAnimationFrame(() =>
-          runOnUI(animateToPoint)(snapPoints[_providedIndex])
-        );
+        const newSnapPoint = snapPoints[_providedIndex];
+        requestAnimationFrame(() => runOnUI(animateToPoint)(newSnapPoint));
         didMountOnAnimate.current = true;
       }
     }, [
@@ -507,9 +509,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
      */
     useEffect(() => {
       if (isLayoutCalculated && currentIndexRef.current !== -1) {
-        requestAnimationFrame(() =>
-          runOnUI(animateToPoint)(snapPoints[currentIndexRef.current])
-        );
+        const newSnapPoint = snapPoints[currentIndexRef.current];
+        requestAnimationFrame(() => runOnUI(animateToPoint)(newSnapPoint));
       }
     }, [isLayoutCalculated, snapPoints, animateToPoint]);
 
@@ -606,6 +607,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         />
         <BottomSheetContainer
           key="BottomSheetContainer"
+          containerHeight={safeContainerHeight}
           shouldMeasureHeight={shouldMeasureContainerHeight}
           onMeasureHeight={handleOnContainerMeasureHeight}
         >

--- a/src/components/bottomSheetContainer/BottomSheetContainer.tsx
+++ b/src/components/bottomSheetContainer/BottomSheetContainer.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { View } from 'react-native';
 import isEqual from 'lodash.isequal';
 import type { BottomSheetContainerProps } from './types';
@@ -6,6 +6,7 @@ import { styles } from './styles';
 
 const BottomSheetContainerComponent = ({
   shouldMeasureHeight,
+  containerHeight,
   onMeasureHeight,
   children,
 }: BottomSheetContainerProps) => {
@@ -22,12 +23,22 @@ const BottomSheetContainerComponent = ({
   );
   //#endregion
 
+  //#region styles
+  const containerStyle = useMemo(
+    () => [
+      styles.container,
+      containerHeight ? { height: containerHeight } : {},
+    ],
+    [containerHeight]
+  );
+  //#endregion
+
   //#region render
   // console.log('BottomSheetContainer', 'render', shouldMeasureHeight);
   return (
     <View
       pointerEvents="box-none"
-      style={styles.container}
+      style={containerStyle}
       onLayout={shouldMeasureHeight ? handleOnLayout : undefined}
       children={children}
     />

--- a/src/components/bottomSheetContainer/styles.ts
+++ b/src/components/bottomSheetContainer/styles.ts
@@ -3,5 +3,6 @@ import { StyleSheet } from 'react-native';
 export const styles = StyleSheet.create({
   container: {
     ...StyleSheet.absoluteFillObject,
+    overflow: 'hidden',
   },
 });

--- a/src/components/bottomSheetContainer/types.d.ts
+++ b/src/components/bottomSheetContainer/types.d.ts
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 
 export interface BottomSheetContainerProps {
   shouldMeasureHeight: boolean;
+  containerHeight?: number;
   onMeasureHeight: (height: number) => void;
   children: ReactNode;
 }


### PR DESCRIPTION
close #251 

## Motivation

for some reason when when passing a parameter from an array, in android it will crash

```ts
// CRASH
requestAnimationFrame(() => runOnUI(animateToPoint)(snapPoints[currentIndexRef.current]));

// FIX
const newSnapPoint = snapPoints[currentIndexRef.current];
requestAnimationFrame(() => runOnUI(animateToPoint)(newSnapPoint));

``` 

## Installation 

```bash
yarn add ssh://git@github.com:gorhom/react-native-bottom-sheet#fix/prevent-crash-on-container-height-resizing
```