### PR TITLE
fix: allow "0%" snap points

### DIFF
--- a/src/utilities/validateSnapPoint.ts
+++ b/src/utilities/validateSnapPoint.ts
@@ -14,7 +14,8 @@ export const validateSnapPoint = (snapPoint: any) => {
 
   invariant(
     typeof snapPoint === 'number' ||
-      (typeof snapPoint === 'string' && Number(snapPoint.split('%')[0])),
+      (typeof snapPoint === 'string' &&
+        !Number.isNaN(Number(snapPoint.split('%')[0]))),
     `'${snapPoint}' is not a valid percentage snap point! expected percentage snap point must be only numbers and '%'. e.g. '50%'`
   );
 };


### PR DESCRIPTION
## Motivation

I setup my snap points using percentages, `["0%", "10%", "60%"]` but got an error saying

> Invariant Violation: '0%' is not a valid percentage snap point! expected percentage snap point must be only numbers and '%'. e.g. '50%'.

This is because the invariant uses the result of the `Number` constructor on the part before the percentage sign - which returns `0` here which is falsey.

This is easily fixed by using the number `0` rather than the string percentage but it took me a minute or two to realise I could mix numbers and % as my head was in 'percentage mode', so I thought a PR to allow `"0%"` might save someone else a few minutes of their time. This PR checks `Number.isNaN` on the output of the `Number` constructor which allows for 0 and any other legitimate number.
