### PR TITLE
Updating getting started.mdx

### DIFF
--- a/website/docs/getting-started.mdx
+++ b/website/docs/getting-started.mdx
@@ -87,7 +87,7 @@ yarn add @gorhom/bottom-sheet@^3
 This library needs these dependencies to be installed in your project before you can use it:
 
 ```bash
-yarn add react-native-reanimated@2.0.0-rc.1 react-native-gesture-handler
+yarn add react-native-reanimated@2.0.0-rc.2 react-native-gesture-handler
 ```
 
 :::info


### PR DESCRIPTION
Upgrading documentation to point package to react-native-animated@2.0.0-rc.2

Please provide enough information so that others can review your pull request:

## Motivation

Issue https://github.com/gorhom/react-native-bottom-sheet/issues/187 required react-native-animated@2.0.0-rc.2 to be installed.

Fixes `setNativeProps is not a function ... this.refs.buttonRef.setNativeProps` is undefined errors when loading bottom sheet for first time.

