### PR TITLE
Fix crash on android while fill snap point in percent on version 2.2.2.

### DIFF
--- a/src/utilities/normalizeSnapPoints.ts
+++ b/src/utilities/normalizeSnapPoints.ts
@@ -10,7 +10,15 @@ export const normalizeSnapPoints = (
 ) =>
   snapPoints.map(snapPoint => {
     validateSnapPoint(snapPoint);
-    return typeof snapPoint === 'number'
-      ? snapPoint
-      : (Number(snapPoint.split('%')[0]) * (containerHeight - topInset)) / 100;
+    if (typeof snapPoint === "number") {
+      return snapPoint
+    } else {
+      // keep two decimal places
+      let result = (Number(snapPoint.split('%')[0]) * (containerHeight - topInset)) / 100;
+      const decimalIndex = `${result}`.indexOf(".");
+      if (decimalIndex >= 0 && `${result}`.length > (decimalIndex + 2)) {
+        result = Number(`${result}`.substr(0, decimalIndex + 2 + 1));
+      }
+      return result
+    }
   });


### PR DESCRIPTION
Just like "90%", the result is 30.1000000000000023.
It will be crash on BottomSheet.tsx on code :

return interpolate(position, {
        inputRange: adjustedSnapPoints,
        outputRange: adjustedSnapPointsIndexes,
        extrapolate: Extrapolate.CLAMP,
      });
