### PR TITLE
Fix type export of internal modal

### DIFF
--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -10,5 +10,5 @@ export {
 export {
   BottomSheetModalInternalContext,
   BottomSheetModalInternalProvider,
-  BottomSheetModalInternalContextType,
 } from './modal/internal';
+export type { BottomSheetModalInternalContextType } from './modal/internal';


### PR DESCRIPTION
## Motivation

Using expo-next triggers this error:
```
error - ./node_modules/@gorhom/bottom-sheet/lib/module/contexts/index.js
Attempted import error: 'BottomSheetModalInternalContextType' is not exported from './modal/internal'.
```