### PR TITLE
fix: prevent closing when sheet is out of screen

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -201,6 +201,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         ? safeContainerHeight
         : snapPoints[currentIndexRef.current];
     }, [snapPoints, animateOnMount, safeContainerHeight]);
+    const currentPositionRef = useRef<number>(initialPosition);
     //#endregion
 
     //#region gestures
@@ -369,7 +370,11 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     );
     const handleClose = useCallback(() => {
       const currentIndexValue = currentIndexRef.current;
-      if (currentIndexValue === -1 || isClosing.current) {
+      if (
+        currentIndexValue === -1 ||
+        isClosing.current ||
+        currentPositionRef.current === safeContainerHeight
+      ) {
         return;
       }
       isClosing.current = true;
@@ -565,6 +570,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
             });
 
             currentIndexRef.current = currentPositionIndex;
+            currentPositionRef.current = args[0];
             refreshUIElements();
             handleOnChange(currentPositionIndex);
           }),


### PR DESCRIPTION
Closes #321 

## Motivation

when user add `0` to snap points and then try to close sheet, it won't reset `isClosing` that will prevent all other events.

## Installation

```bash
yarn add ssh://git@github.com:gorhom/react-native-bottom-sheet#fix/prevent-closing-when-sheet-is-out-of-screen
```