### PR TITLE
feat: adds optional snapPointIndex parameter to modal present method

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -363,7 +363,10 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         );
         if (isClosing.current && !force) {
           return;
+        } else {
+          isClosing.current = false;
         }
+
         manualSnapToPoint.setValue(snapPoints[index]);
       },
       [snapPoints, manualSnapToPoint]

--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -120,13 +120,17 @@ const BottomSheetModalComponent = forwardRef<
   //#endregion
 
   //#region public methods
-  const handlePresent = useCallback(() => {
-    requestAnimationFrame(() => {
-      nextIndexRef.current = index;
-      setMount(true);
-      mountSheet(key, ref);
-    });
-  }, [key, mountSheet, ref, index]);
+  const handlePresent = useCallback(
+    (snapPointIndex?: number) => {
+      requestAnimationFrame(() => {
+        nextIndexRef.current =
+          snapPointIndex || snapPointIndex === 0 ? snapPointIndex : index;
+        setMount(true);
+        mountSheet(key, ref);
+      });
+    },
+    [key, mountSheet, ref, index]
+  );
   const handleDismiss = useCallback(
     (force: boolean = false) => {
       if (force) {


### PR DESCRIPTION
Adds an optional parameter to the modal's `present` method to be able to present the modal on the desired index, rather than the one defined as prop for the `BottomSheetModal` component.

Also fixes an issue with stacked modals where the modals could stuck in a closing state when rapidly switching between them, or "grabbing" them in-between their animation.

## Motivation

Wanted to present the modal on a different snap point depending on the scenario. It was counter intuitive to use the prop and maintain a state to keep track of the indexes. Other issue was modals getting "stuck" in their state when swapping them rapidly, breaking the modal stack.

