### PR TITLE
feat: changes all arrays to ReadonlyArray

### DIFF
--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -16,13 +16,13 @@ export type BottomSheetProps = {
   /**
    * Points for the bottom sheet to snap to. It accepts array of number, string or mix.
    * String values should be a percentage.
-   * @type Array<string | number>
+   * @type ReadonlyArray<string | number>
    * @example
    * snapPoints={[200, 500]}
    * snapPoints={[200, '50%']}
    * snapPoints={[-1, '100%']}
    */
-  snapPoints: Array<string | number>;
+  snapPoints: ReadonlyArray<string | number>;
   /**
    * Handle height helps to calculate the internal container and sheet layouts,
    * if `handleComponent` is provided, the library internally will calculate its layout,
@@ -171,7 +171,7 @@ export interface BottomSheetTransitionConfig
   handlePanGestureVelocityY: Animated.Value<number>;
 
   scrollableContentOffsetY: Animated.Value<number>;
-  snapPoints: number[];
+  snapPoints: ReadonlyArray<number>;
   initialPosition: number;
 
   currentIndexRef: React.RefObject<number>;

--- a/src/hooks/useNormalizedSnapPoints.ts
+++ b/src/hooks/useNormalizedSnapPoints.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { normalizeSnapPoints } from '../utilities';
 
 export const useNormalizedSnapPoints = (
-  snapPoints: Array<number | string>,
+  snapPoints: ReadonlyArray<number | string>,
   containerHeight: number = 0,
   handleHeight: number = 0
 ) =>

--- a/src/hooks/useReactiveValues.ts
+++ b/src/hooks/useReactiveValues.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import Animated from 'react-native-reanimated';
 
-export const useReactiveValues = (values: number[]) => {
+export const useReactiveValues = (values: ReadonlyArray<number>) => {
   // ref
   const ref = useRef<Animated.Value<number>[]>(null);
   if (ref.current === null) {

--- a/src/utilities/normalizeSnapPoints.ts
+++ b/src/utilities/normalizeSnapPoints.ts
@@ -4,7 +4,7 @@ import { validateSnapPoint } from './validateSnapPoint';
  * Converts snap points with percentage to fixed numbers.
  */
 export const normalizeSnapPoints = (
-  snapPoints: Array<number | string>,
+  snapPoints: ReadonlyArray<number | string>,
   containerHeight: number
 ) =>
   snapPoints.map(snapPoint => {


### PR DESCRIPTION
## Motivation

When using arrays in props it is often a better solution to use `ReadonlyArray`. This way, the array cannot be modified in the component that uses it and it is easier to find bugs. 

