### PR TITLE
chore: remove calls to getNode()

### DIFF
--- a/src/components/flatList/FlatList.tsx
+++ b/src/components/flatList/FlatList.tsx
@@ -52,7 +52,7 @@ const BottomSheetFlatListComponent = forwardRef(
 
     // effects
     // @ts-ignore
-    useImperativeHandle(ref, () => scrollableRef.current!.getNode());
+    useImperativeHandle(ref, () => scrollableRef.current);
     useFocusHook(handleSettingScrollable);
 
     // render

--- a/src/components/scrollView/ScrollView.tsx
+++ b/src/components/scrollView/ScrollView.tsx
@@ -52,7 +52,7 @@ const BottomSheetScrollViewComponent = forwardRef(
 
     // effects
     // @ts-ignore
-    useImperativeHandle(ref, () => scrollableRef.current!.getNode());
+    useImperativeHandle(ref, () => scrollableRef.current);
     useFocusHook(handleSettingScrollable);
 
     return (

--- a/src/components/sectionList/SectionList.tsx
+++ b/src/components/sectionList/SectionList.tsx
@@ -51,7 +51,7 @@ const BottomSheetSectionListComponent = forwardRef(
     } = useBottomSheetInternal();
     // effects
     // @ts-ignore
-    useImperativeHandle(ref, () => scrollableRef.current!.getNode());
+    useImperativeHandle(ref, () => scrollableRef.current);
     useFocusHook(handleSettingScrollable);
 
     // render

--- a/src/hooks/useScrollableInternal.ts
+++ b/src/hooks/useScrollableInternal.ts
@@ -54,7 +54,7 @@ export const useScrollableInternal = (type: ScrollableType) => {
         id: id,
         type,
         // @ts-ignore
-        node: scrollableRef.current!.getNode(),
+        node: scrollableRef.current,
       });
     } else {
       console.warn(`Couldn't find the scrollable node handle id!`);


### PR DESCRIPTION
This PR removes calls to `getNode()` in `v2`

## Motivation

Resolve the warning `"Calling getNode() on the ref of an Animated component is no longer necessary.`

Related: https://github.com/gorhom/react-native-bottom-sheet/issues/364, https://github.com/gorhom/react-native-bottom-sheet/issues/363

Seems to be resolved in `v3` with https://github.com/gorhom/react-native-bottom-sheet/pull/166