### PR TITLE
fix: allow passing custom style to backdrop component

### DIFF
--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -83,7 +83,7 @@ const BottomSheetBackdropComponent = ({
     flex: 1,
   }));
   const containerStyle = useMemo(
-    () => [style, styles.container, containerAnimatedStyle],
+    () => [styles.container, style, containerAnimatedStyle],
     [style, containerAnimatedStyle]
   );
   //#endregion


### PR DESCRIPTION
## Motivation

Allow modification of the style property. This will allow overriding the `backgroundColor`.

This was fixed on #211 but then reverted on #378 (probably by accident).