### PR TITLE
chore: minor refactor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,16 +3,6 @@ module.exports = {
   extends: ['@react-native-community', 'prettier'],
   rules: {
     'no-console': ['error', { allow: ['warn', 'error'] }],
-    'prettier/prettier': [
-      'error',
-      {
-        printWidth: 80,
-        arrowParens: 'avoid',
-        singleQuote: true,
-        tabWidth: 2,
-        trailingComma: 'es5',
-        useTabs: false,
-      },
-    ],
+    'prettier/prettier': 'error',
   },
 };

--- a/example/src/components/contactListContainer/ContactListContainer.tsx
+++ b/example/src/components/contactListContainer/ContactListContainer.tsx
@@ -14,9 +14,10 @@ const ContactListContainerComponent = ({
   headerStyle: _headerStyle,
   onItemPress,
 }: ContactListContainerProps) => {
-  const headerStyle = useMemo(() => [styles.headerContainer, _headerStyle], [
-    _headerStyle,
-  ]);
+  const headerStyle = useMemo(
+    () => [styles.headerContainer, _headerStyle],
+    [_headerStyle]
+  );
   return (
     <>
       <View style={headerStyle}>

--- a/example/src/screens/advanced/BackdropExample.tsx
+++ b/example/src/screens/advanced/BackdropExample.tsx
@@ -6,9 +6,8 @@ import ContactListContainer from '../../components/contactListContainer';
 
 const BackdropExample = () => {
   // state
-  const [backdropPressBehavior, setBackdropPressBehavior] = useState<
-    'none' | 'close' | 'collapse'
-  >('collapse');
+  const [backdropPressBehavior, setBackdropPressBehavior] =
+    useState<'none' | 'close' | 'collapse'>('collapse');
 
   // hooks
   const bottomSheetRef = useRef<BottomSheet>(null);

--- a/example/src/screens/modal/BackdropExample.tsx
+++ b/example/src/screens/modal/BackdropExample.tsx
@@ -11,9 +11,8 @@ import withModalProvider from '../withModalProvider';
 
 const BackdropExample = () => {
   // state
-  const [backdropPressBehavior, setBackdropPressBehavior] = useState<
-    'none' | 'close' | 'collapse'
-  >('collapse');
+  const [backdropPressBehavior, setBackdropPressBehavior] =
+    useState<'none' | 'close' | 'collapse'>('collapse');
   // refs
   const bottomSheetRef = useRef<BottomSheetModal>(null);
 

--- a/src/components/bottomSheetHandleContainer/BottomSheetHandleContainer.tsx
+++ b/src/components/bottomSheetHandleContainer/BottomSheetHandleContainer.tsx
@@ -44,11 +44,6 @@ function BottomSheetHandleContainerComponent({
 
     return refs;
   }, [_providedSimultaneousHandlers, _internalSimultaneousHandlers]);
-
-  const shouldRenderHandle = useMemo(
-    () => _providedHandleComponent !== null,
-    [_providedHandleComponent]
-  );
   //#endregion
 
   //#region callbacks
@@ -96,6 +91,7 @@ function BottomSheetHandleContainerComponent({
     );
   }, [animatedIndex, animatedPosition, _providedHandleComponent]);
 
+  const shouldRenderHandle = _providedHandleComponent !== null;
   return shouldRenderHandle ? (
     <PanGestureHandler
       enabled={enableHandlePanningGesture}

--- a/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
+++ b/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
@@ -74,7 +74,7 @@ export function createBottomSheetScrollableComponent<T, P>(
             ref={scrollableRef}
             overScrollMode={overScrollMode}
             scrollEventThrottle={16}
-            onScrollBeginDrag={handleScrollEvent}
+            onScroll={handleScrollEvent}
             animatedProps={scrollableAnimatedProps}
             style={containerStyle}
           />

--- a/src/hooks/useScrollableInternal.ts
+++ b/src/hooks/useScrollableInternal.ts
@@ -109,7 +109,6 @@ export const useScrollableInternal = () => {
             : 0;
           // @ts-ignore
           scrollTo(scrollableRef, 0, lockPosition, false);
-          scrollableContentOffsetY.value = lockPosition;
           scrollableContentOffsetY.value = 0;
           return;
         }

--- a/src/utilities/normalizeSnapPoint.ts
+++ b/src/utilities/normalizeSnapPoint.ts
@@ -16,5 +16,5 @@ export const normalizeSnapPoint = (
     normalizedSnapPoint =
       (Number(normalizedSnapPoint.split('%')[0]) * containerHeight) / 100;
   }
-  return Math.round(Math.max(0, containerHeight - normalizedSnapPoint));
+  return Math.max(0, containerHeight - normalizedSnapPoint);
 };

--- a/src/utilities/normalizeSnapPoint.ts
+++ b/src/utilities/normalizeSnapPoint.ts
@@ -16,5 +16,5 @@ export const normalizeSnapPoint = (
     normalizedSnapPoint =
       (Number(normalizedSnapPoint.split('%')[0]) * containerHeight) / 100;
   }
-  return Math.max(0, containerHeight - normalizedSnapPoint);
+  return Math.round(Math.max(0, containerHeight - normalizedSnapPoint));
 };


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

1) eslintrc : there is no need to pass rules to prettier, it will take them from prettierrc
2) BottomSheetHandleContainer.tsx - useMemo is not needed for a boolean
3) onScrollBeginDrag -> onScroll - the events listener should be passed under `onScroll` as documented in https://docs.swmansion.com/react-native-reanimated/docs/2.0.0-rc.2/api/useAnimatedScrollHandler/#returns
4) useScrollableInternal.ts - removed a line that likely has no effect
 
~~Math.round - on android device I was getting some wild snap points like 123.999428435834 and figured it might be nicer to round them to integer numbers so that when there is some arithmetics done (eg adding some numbers and then comparing numbers via === can fail) it might be safer to do work with whole numbers.~~

tested locally with example app
