### PR TITLE
fix: ts typings for sectionlist to mirror rn core types

### DIFF
--- a/src/components/bottomSheetScrollable/BottomSheetSectionList.tsx
+++ b/src/components/bottomSheetScrollable/BottomSheetSectionList.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import {
+  DefaultSectionT,
   SectionList as RNSectionList,
   SectionListProps as RNSectionListProps,
 } from 'react-native';
@@ -16,12 +17,12 @@ const AnimatedSectionList =
 const BottomSheetSectionListComponent =
   createBottomSheetScrollableComponent<
     BottomSheetSectionListMethods,
-    BottomSheetSectionListProps<any>
+    BottomSheetSectionListProps<any, DefaultSectionT>
   >(AnimatedSectionList);
 
 const BottomSheetSectionList = memo(BottomSheetSectionListComponent);
 BottomSheetSectionList.displayName = 'BottomSheetSectionList';
 
-export default BottomSheetSectionList as <T>(
-  props: BottomSheetSectionListProps<T>
+export default BottomSheetSectionList as <ItemT, SectionT = DefaultSectionT>(
+  props: BottomSheetSectionListProps<ItemT, SectionT>
 ) => ReturnType<typeof BottomSheetSectionList>;

--- a/src/components/bottomSheetScrollable/types.d.ts
+++ b/src/components/bottomSheetScrollable/types.d.ts
@@ -170,8 +170,8 @@ export interface BottomSheetScrollViewMethods {
 //#endregion
 
 //#region SectionList
-type BottomSheetSectionListProps<T> = Omit<
-  Animated.AnimateProps<SectionListProps<T>>,
+type BottomSheetSectionListProps<ItemT, SectionT> = Omit<
+  Animated.AnimateProps<SectionListProps<ItemT, SectionT>>,
   'decelerationRate' | 'onScrollBeginDrag' | 'scrollEventThrottle'
 > &
   BottomSheetScrollableProps & {


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

the types for SectionList in RN core are:

`interface SectionListProps<ItemT, SectionT = DefaultSectionT>`

but the typings of the exported `BottomSheetSectionList` are `BottomSheetSectionListProps<T>` and do not allow passing the second parameter. This PR aligns the typings to be the same as in RN core

can be tested with:

```
import { SectionList as RNSectionList, Text } from 'react-native';
import React from 'react';
import BottomSheetSectionList from './BottomSheetSectionList';

type ItemType = {
  number: number;
};
type SectionsType = {
  title: string;
  data: Array<ItemType>;
};
export const TSTest = () => {
  const sections = [
    {
      title: 'Main dishes',
      data: [{ number: 1 }, { number: 2 }],
    },
    {
      title: 'side dishes',
      data: [{ number: 1 }, { number: 2 }],
    },
  ];
  return (
    <>
      <RNSectionList<ItemType, SectionsType>
        sections={sections}
        renderItem={props => <Text>{props.item}</Text>}
      />
      <BottomSheetSectionList<ItemType, SectionsType>
        sections={sections}
        renderItem={props => <Text>{props.item}</Text>}
      />
    </>
  );
};
```
