### PR TITLE
fix: background color not consistently applied

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -5,7 +5,7 @@ import React, {
   useImperativeHandle,
   memo,
 } from 'react';
-import { Keyboard, Platform } from 'react-native';
+import { Keyboard, Platform, ViewStyle } from 'react-native';
 import invariant from 'invariant';
 import Animated, {
   useAnimatedReaction,
@@ -960,10 +960,21 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     const contentMaskContainerAnimatedStyle = useAnimatedStyle(() => ({
       paddingBottom: animatedContainerHeight.value,
     }));
-    const contentMaskContainerStyle = useMemo(
-      () => [styles.contentMaskContainer, contentMaskContainerAnimatedStyle],
-      [contentMaskContainerAnimatedStyle]
-    );
+
+    const providedBackgroundColorStyle: undefined | ViewStyle = useMemo(() => {
+      if (_providedStyle?.backgroundColor) {
+        return { backgroundColor: _providedStyle.backgroundColor } as ViewStyle;
+      }
+      return undefined;
+    }, [_providedStyle]);
+
+    const contentMaskContainerStyle = useMemo(() => {
+      return [
+        styles.contentMaskContainer,
+        contentMaskContainerAnimatedStyle,
+        ...(providedBackgroundColorStyle ? [providedBackgroundColorStyle] : []),
+      ];
+    }, [contentMaskContainerAnimatedStyle, providedBackgroundColorStyle]);
     //#endregion
 
     //#region effects
@@ -1278,6 +1289,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
                 keyboardBehavior={keyboardBehavior}
                 handlePanGestureHandler={handlePanGestureHandler}
                 handleComponent={handleComponent}
+                style={providedBackgroundColorStyle}
               />
             </BottomSheetInternalProvider>
           </Animated.View>

--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -37,10 +37,7 @@ const BottomSheetBackdropComponent = ({
 
   //#region variables
   const containerRef = useRef<Animated.View>(null);
-  const pointerEvents = useMemo(
-    () => (enableTouchThrough ? 'none' : 'auto'),
-    [enableTouchThrough]
-  );
+  const pointerEvents = enableTouchThrough ? 'none' : 'auto';
   //#endregion
 
   //#region callbacks

--- a/src/components/bottomSheetBackgroundContainer/BottomSheetBackgroundContainer.tsx
+++ b/src/components/bottomSheetBackgroundContainer/BottomSheetBackgroundContainer.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo } from 'react';
 import BottomSheetBackground from '../bottomSheetBackground';
 import type { BottomSheetBackgroundContainerProps } from './types';
 import { styles } from './styles';
@@ -8,10 +8,8 @@ const BottomSheetBackgroundContainerComponent = ({
   animatedPosition,
   backgroundComponent: _providedBackgroundComponent,
 }: BottomSheetBackgroundContainerProps) => {
-  const BackgroundComponent = useMemo(
-    () => _providedBackgroundComponent || BottomSheetBackground,
-    [_providedBackgroundComponent]
-  );
+  const BackgroundComponent =
+    _providedBackgroundComponent || BottomSheetBackground;
   return _providedBackgroundComponent === null ? null : (
     <BackgroundComponent
       pointerEvents="none"

--- a/src/components/bottomSheetHandleContainer/BottomSheetHandleContainer.tsx
+++ b/src/components/bottomSheetHandleContainer/BottomSheetHandleContainer.tsx
@@ -15,6 +15,7 @@ function BottomSheetHandleContainerComponent({
   handlePanGestureHandler,
   handleHeight,
   handleComponent: _providedHandleComponent,
+  style,
 }: BottomSheetHandleContainerProps) {
   //#region variables
   const {
@@ -106,6 +107,7 @@ function BottomSheetHandleContainerComponent({
         accessibilityLabel="Bottom Sheet handle"
         accessibilityHint="Drag up or down to extend or minimize the Bottom Sheet"
         onLayout={handleContainerLayout}
+        style={style}
       >
         {renderHandle()}
       </Animated.View>

--- a/src/components/bottomSheetHandleContainer/types.d.ts
+++ b/src/components/bottomSheetHandleContainer/types.d.ts
@@ -3,6 +3,7 @@ import type Animated from 'react-native-reanimated';
 import type { BottomSheetProps } from '../bottomSheet';
 import type { BottomSheetHandleProps } from '../bottomSheetHandle';
 import type { useInteractivePanGestureHandlerConfigs } from '../../hooks/useInteractivePanGestureHandler';
+import { ViewStyle } from 'react-native';
 
 export interface BottomSheetHandleContainerProps
   extends Pick<PanGestureHandlerProperties, 'simultaneousHandlers'>,
@@ -17,4 +18,5 @@ export interface BottomSheetHandleContainerProps
     BottomSheetHandleProps {
   handlePanGestureHandler: any;
   handleHeight: Animated.SharedValue<number>;
+  style?: ViewStyle;
 }


### PR DESCRIPTION

## Motivation

this PR fixes an issue that I recorded here:

https://user-images.githubusercontent.com/1566403/120942323-83df4980-c728-11eb-82ef-48b2953e3b16.mp4

please make sure to watch the video _without_ the playback controls visible, to see an issue in the safe area

the issue can be reproduced using the following changes: https://github.com/vonovak/react-native-bottom-sheet/commit/56e1959d4f5f2334c5432356790391fae7befe6e (note these are not done on the latest v4 alpha 10).

basically, I tried to set the background color of the sheet content as well as the sheet handle to black and found some parts of the sheet to have white background, not black

The changes done in this PR can be tested using these changes: https://github.com/vonovak/react-native-bottom-sheet/commit/7b0d234b3d22ea282f418fd5fd5eb0e066653f2c

What the fix does is that it relies on the consumer passing the `backgroundColor` style to `BottomSheet` when they encounter this issue. When the style is present, we extract the background color from it and apply it to the necessary places (`style` passed to `BottomSheetHandleContainer` and the `contentMaskContainerStyle`)

the code might feel a little clumsy because I tried to avoid some TS errors, feel free to edit it or suggest another approach :)) 

Thanks!