### PR TITLE
feat: Added bottomInset to BottomSheetBackdropContainer

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -617,6 +617,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           animatedIndex={animatedIndex}
           animatedPosition={animatedPosition}
           backdropComponent={backdropComponent}
+          bottomInset={bottomInset}
         />
         <BottomSheetContainer
           key="BottomSheetContainer"

--- a/src/components/bottomSheetBackdrop/types.d.ts
+++ b/src/components/bottomSheetBackdrop/types.d.ts
@@ -12,6 +12,12 @@ export interface BottomSheetBackdropProps extends Pick<ViewProps, 'style'> {
    * @type Animated.Value<number>
    */
   animatedPosition: Animated.Node<number>;
+  /**
+   * Current sheet absolute bottom position offset of backdrop
+   * @type number
+   * @default '0'
+   */
+  bottomInset?: number;
 }
 
 export type BackdropPressBehavior = 'none' | 'close' | 'collapse' | number;

--- a/src/components/bottomSheetBackdropContainer/BottomSheetBackdropContainer.tsx
+++ b/src/components/bottomSheetBackdropContainer/BottomSheetBackdropContainer.tsx
@@ -7,12 +7,14 @@ const BottomSheetBackdropContainerComponent = ({
   animatedIndex,
   animatedPosition,
   backdropComponent: BackdropComponent,
+  bottomInset,
 }: BottomSheetBackdropContainerProps) => {
   return BackdropComponent ? (
     <BackdropComponent
       animatedIndex={animatedIndex}
       animatedPosition={animatedPosition}
-      style={styles.container}
+      // eslint-disable-next-line react-native/no-inline-styles
+      style={[styles.container, { bottom: bottomInset ? bottomInset : 0 }]}
     />
   ) : null;
 };

--- a/src/components/bottomSheetHandleContainer/BottomSheetHandleContainer.tsx
+++ b/src/components/bottomSheetHandleContainer/BottomSheetHandleContainer.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { memo, useCallback } from 'react';
 import { PanGestureHandler } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
 import isEqual from 'lodash.isequal';


### PR DESCRIPTION
## Motivation

A newly added feature to BottomSheet is the bottomInset which offsets a BottomSheet from the bottom. However, the backdrop component should also receive the same offset. This PR adds the bottomInset to `BottomSheetBackdropContainer` by setting the absolute bottom in styles to the bottomInset, if it exists, or defaults to 0.
Also removed an unused `useMemo` in `BottomSheetHandleContainer`
