### PR TITLE
feat: Added bottomInset to BottomSheetBackdropContainer

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1252,6 +1252,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           animatedIndex={animatedIndex}
           animatedPosition={animatedPosition}
           backdropComponent={backdropComponent}
+          bottomInset={bottomInset}
         />
         <BottomSheetContainer
           key="BottomSheetContainer"

--- a/src/components/bottomSheetBackdropContainer/BottomSheetBackdropContainer.tsx
+++ b/src/components/bottomSheetBackdropContainer/BottomSheetBackdropContainer.tsx
@@ -6,12 +6,13 @@ const BottomSheetBackdropContainerComponent = ({
   animatedIndex,
   animatedPosition,
   backdropComponent: BackdropComponent,
+  bottomInset
 }: BottomSheetBackdropContainerProps) => {
   return BackdropComponent ? (
     <BackdropComponent
       animatedIndex={animatedIndex}
       animatedPosition={animatedPosition}
-      style={styles.container}
+      style={[styles.container, { bottom: bottomInset ? bottomInset : 0 }]}
     />
   ) : null;
 };

--- a/src/components/bottomSheetBackdropContainer/styles.ts
+++ b/src/components/bottomSheetBackdropContainer/styles.ts
@@ -6,6 +6,5 @@ export const styles = StyleSheet.create({
     top: 0,
     left: 0,
     right: 0,
-    bottom: 0,
   },
 });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -88,6 +88,12 @@ export interface BottomSheetVariables {
    * @type Animated.Value<number>
    */
   animatedPosition: Animated.SharedValue<number>;
+  /**
+   * Current sheet absolute bottom position offset of backdrop.
+   * @type number
+   * @default '0'
+   */
+  bottomInset?: number;
 }
 
 //#region scrollables


### PR DESCRIPTION
## Motivation

A newly added feature to BottomSheet is the `bottomInset` which offsets a BottomSheet from the bottom. However, the backdrop component should also receive the same offset. This PR adds the bottomInset to `BottomSheetBackdropContainer` by setting the absolute bottom in styles to the bottomInset, if it exists, or defaults to 0.

