### PR TITLE
Do not allow to rerun animation if child rerendered during "collapse"

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -386,6 +386,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       if (isClosing.current) {
         return;
       }
+      isClosing.current = true;
       manualSnapToPoint.setValue(snapPoints[0]);
     }, [snapPoints, manualSnapToPoint]);
     //#endregion


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

If during closing animation content of bottom sheet got rerender, bottom sheet will be reopened.

