### PR TITLE
chore: remove unnecessary useMemos in v4

### DIFF
--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -37,10 +37,7 @@ const BottomSheetBackdropComponent = ({
 
   //#region variables
   const containerRef = useRef<Animated.View>(null);
-  const pointerEvents = useMemo(
-    () => (enableTouchThrough ? 'none' : 'auto'),
-    [enableTouchThrough]
-  );
+  const pointerEvents = enableTouchThrough ? 'none' : 'auto';
   //#endregion
 
   //#region callbacks

--- a/src/components/bottomSheetBackgroundContainer/BottomSheetBackgroundContainer.tsx
+++ b/src/components/bottomSheetBackgroundContainer/BottomSheetBackgroundContainer.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo } from 'react';
 import BottomSheetBackground from '../bottomSheetBackground';
 import type { BottomSheetBackgroundContainerProps } from './types';
 import { styles } from './styles';
@@ -8,10 +8,8 @@ const BottomSheetBackgroundContainerComponent = ({
   animatedPosition,
   backgroundComponent: _providedBackgroundComponent,
 }: BottomSheetBackgroundContainerProps) => {
-  const BackgroundComponent = useMemo(
-    () => _providedBackgroundComponent || BottomSheetBackground,
-    [_providedBackgroundComponent]
-  );
+  const BackgroundComponent =
+    _providedBackgroundComponent || BottomSheetBackground;
   return _providedBackgroundComponent === null ? null : (
     <BackgroundComponent
       pointerEvents="none"


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

Explain the **motivation** for making this change. 

this is pretty much the same as https://github.com/gorhom/react-native-bottom-sheet/pull/413 :)

there's no need to memoize primitives (string) or components that are passed as props from above
