### PR TITLE
chore: add type exports for default components

### DIFF
--- a/src/components/bottomSheetBackdrop/index.ts
+++ b/src/components/bottomSheetBackdrop/index.ts
@@ -1,2 +1,5 @@
 export { default } from './BottomSheetBackdrop';
-export type { BottomSheetBackdropProps } from './types';
+export type {
+  BottomSheetBackdropProps,
+  BottomSheetDefaultBackdropProps,
+} from './types';

--- a/src/components/bottomSheetHandle/index.ts
+++ b/src/components/bottomSheetHandle/index.ts
@@ -1,2 +1,5 @@
 export { default } from './BottomSheetHandle';
-export type { BottomSheetHandleProps } from './types';
+export type {
+  BottomSheetHandleProps,
+  BottomSheetDefaultHandleProps,
+} from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,9 +39,15 @@ export const {
 //#region types
 export type { BottomSheetProps } from './components/bottomSheet';
 export type { BottomSheetModalProps } from './components/bottomSheetModal';
-export type { BottomSheetHandleProps } from './components/bottomSheetHandle';
+export type {
+  BottomSheetHandleProps,
+  BottomSheetDefaultHandleProps,
+} from './components/bottomSheetHandle';
 export type { BottomSheetBackgroundProps } from './components/bottomSheetBackground';
-export type { BottomSheetBackdropProps } from './components/bottomSheetBackdrop';
+export type {
+  BottomSheetBackdropProps,
+  BottomSheetDefaultBackdropProps,
+} from './components/bottomSheetBackdrop';
 
 export type {
   BottomSheetFlatListMethods,


### PR DESCRIPTION
## Motivation

Added type exports for default components (`BottomSheetDefaultBackdrop`, `BottomSheetDefaultHandle`, `BottomSheetDefaultBackdrop`).
When we have such exports, we can do the next:
```tsx
import { BottomSheetBackdrop, BottomSheetDefaultBackdropProps } from '@gorhom/bottom-sheet';

interface AntiFlickerBottomSheetBackdropProps extends BottomSheetDefaultBackdropProps {
  animationDuration: number;
}
...
```