### PR TITLE
Allow usage of index when using dynamic snap points

### DIFF
--- a/src/hooks/useBottomSheetDynamicSnapPoints.ts
+++ b/src/hooks/useBottomSheetDynamicSnapPoints.ts
@@ -29,7 +29,7 @@ export const useBottomSheetDynamicSnapPoints = (
       animatedHandleHeight.value === INITIAL_HANDLE_HEIGHT ||
       animatedContentHeight.value === 0
     ) {
-      return initialSnapPoints.map(_ => INITIAL_SNAP_POINT);
+      return initialSnapPoints.map(() => INITIAL_SNAP_POINT);
     }
     const contentWithHandleHeight =
       animatedContentHeight.value + animatedHandleHeight.value;

--- a/src/hooks/useBottomSheetDynamicSnapPoints.ts
+++ b/src/hooks/useBottomSheetDynamicSnapPoints.ts
@@ -29,7 +29,7 @@ export const useBottomSheetDynamicSnapPoints = (
       animatedHandleHeight.value === INITIAL_HANDLE_HEIGHT ||
       animatedContentHeight.value === 0
     ) {
-      return [INITIAL_SNAP_POINT];
+      return initialSnapPoints.map(_ => INITIAL_SNAP_POINT);
     }
     const contentWithHandleHeight =
       animatedContentHeight.value + animatedHandleHeight.value;


### PR DESCRIPTION
Because the number of snap points is different on the initial frame with the number when the sheet size is known, the bottom sheet could not be used with an index value. To avoid this issue we fill the snap points array with INITIAL_SNAP_POINT, thus snapPoints array will have the same length before the contentHeight is available.
