### PR TITLE
fix: pass correct params to animateToPosition

### DIFF
--- a/example/src/screens/advanced/customGestureHandling/useCustomGestureEventsHandlers.ts
+++ b/example/src/screens/advanced/customGestureHandling/useCustomGestureEventsHandlers.ts
@@ -8,6 +8,7 @@ import {
   SCROLLABLE_TYPE,
   WINDOW_HEIGHT,
   GestureEventHandlerCallbackType,
+  ANIMATION_SOURCE,
 } from '@gorhom/bottom-sheet';
 import { useGestureTranslationY } from './GestureTranslationContext';
 
@@ -210,12 +211,13 @@ export const useCustomGestureEventsHandlers = () => {
   );
   const handleOnEnd: GestureEventHandlerCallbackType = useWorkletCallback(
     function handleOnEnd(
-      type,
+      source,
       { translationY, absoluteY, velocityY },
       context
     ) {
       const highestSnapPoint = animatedHighestSnapPoint.value;
-
+      const isSheetAtHighestSnapPoint =
+        animatedPosition.value === highestSnapPoint;
       /**
        * if the sheet is in a temporary position and the gesture ended above
        * the current position, then we snap back to the temporary position.
@@ -225,7 +227,11 @@ export const useCustomGestureEventsHandlers = () => {
         context.initialPosition >= animatedPosition.value
       ) {
         if (context.initialPosition > animatedPosition.value) {
-          animateToPosition(context.initialPosition, velocityY / 2);
+          animateToPosition(
+            context.initialPosition,
+            ANIMATION_SOURCE.GESTURE,
+            velocityY / 2
+          );
         }
         return;
       }
@@ -291,7 +297,7 @@ export const useCustomGestureEventsHandlers = () => {
           velocityY,
           snapPoints
         );
-        if (type === GESTURE_SOURCE.HANDLE) {
+        if (source === GESTURE_SOURCE.HANDLE) {
           return endingSnapPoint;
         }
         const secondHighestSnapPoint =
@@ -309,33 +315,21 @@ export const useCustomGestureEventsHandlers = () => {
         return;
       }
 
+      const wasGestureHandledByScrollView =
+        source === GESTURE_SOURCE.SCROLLABLE &&
+        animatedScrollableContentOffsetY.value > 0;
       /**
-       * if gesture was picked by scrollable and did not move the sheet,
-       * then exit the method to prevent snapping.
+       * prevents snapping from top to middle / bottom with repeated interrupted scrolls
        */
-      if (
-        (type === GESTURE_SOURCE.SCROLLABLE
-          ? animatedScrollableContentOffsetY.value
-          : 0) > 0 &&
-        context.initialPosition === highestSnapPoint &&
-        animatedPosition.value === highestSnapPoint
-      ) {
+      if (wasGestureHandledByScrollView && isSheetAtHighestSnapPoint) {
         return;
       }
 
-      /**
-       * if gesture started by scrollable dragging the sheet than continue scrolling,
-       * then exit the method to prevent snapping.
-       */
-      if (
-        type === GESTURE_SOURCE.SCROLLABLE &&
-        animatedScrollableContentOffsetY.value > 0 &&
-        animatedPosition.value === highestSnapPoint
-      ) {
-        return;
-      }
-
-      animateToPosition(destinationPoint, velocityY / 2);
+      animateToPosition(
+        destinationPoint,
+        ANIMATION_SOURCE.GESTURE,
+        velocityY / 2
+      );
     },
     [
       enablePanDownToClose,

--- a/example/src/screens/advanced/customGestureHandling/useCustomGestureEventsHandlers.ts
+++ b/example/src/screens/advanced/customGestureHandling/useCustomGestureEventsHandlers.ts
@@ -56,7 +56,7 @@ export const useCustomGestureEventsHandlers = () => {
     [animatedPosition, animatedKeyboardState, animatedScrollableContentOffsetY]
   );
   const handleOnActive: GestureEventHandlerCallbackType = useWorkletCallback(
-    function handleOnActive(type, { translationY }, context) {
+    function handleOnActive(source, { translationY }, context) {
       gestureTranslationY.value = translationY;
 
       let highestSnapPoint =
@@ -92,7 +92,7 @@ export const useCustomGestureEventsHandlers = () => {
        * point, then do not interact with current gesture.
        */
       if (
-        type === GESTURE_SOURCE.SCROLLABLE &&
+        source === GESTURE_SOURCE.SCROLLABLE &&
         isScrollableRefreshable.value &&
         animatedPosition.value === highestSnapPoint
       ) {
@@ -107,7 +107,7 @@ export const useCustomGestureEventsHandlers = () => {
        */
       const negativeScrollableContentOffset =
         (context.initialPosition === highestSnapPoint &&
-          type === GESTURE_SOURCE.SCROLLABLE) ||
+          source === GESTURE_SOURCE.SCROLLABLE) ||
         !context.isScrollablePositionLocked
           ? animatedScrollableContentOffsetY.value * -1
           : 0;
@@ -135,7 +135,7 @@ export const useCustomGestureEventsHandlers = () => {
         context.initialPosition > secondHighestSnapPoint;
 
       const clampedPosition = (() => {
-        if (type === GESTURE_SOURCE.SCROLLABLE) {
+        if (source === GESTURE_SOURCE.SCROLLABLE) {
           const clampSource = (() => {
             if (isDraggingFromBottom) {
               return accumulatedDraggedPosition;
@@ -158,7 +158,7 @@ export const useCustomGestureEventsHandlers = () => {
        */
       if (
         context.isScrollablePositionLocked &&
-        type === GESTURE_SOURCE.SCROLLABLE &&
+        source === GESTURE_SOURCE.SCROLLABLE &&
         animatedPosition.value === highestSnapPoint
       ) {
         context.isScrollablePositionLocked = false;
@@ -169,7 +169,7 @@ export const useCustomGestureEventsHandlers = () => {
        */
       if (enableOverDrag) {
         if (
-          (type === GESTURE_SOURCE.HANDLE ||
+          (source === GESTURE_SOURCE.HANDLE ||
             animatedScrollableType.value === SCROLLABLE_TYPE.VIEW) &&
           draggedPosition < highestSnapPoint
         ) {
@@ -182,7 +182,7 @@ export const useCustomGestureEventsHandlers = () => {
         }
 
         if (
-          type === GESTURE_SOURCE.HANDLE &&
+          source === GESTURE_SOURCE.HANDLE &&
           draggedPosition > lowestSnapPoint
         ) {
           const resistedPosition =

--- a/src/hooks/useGestureEventsHandlersDefault.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.tsx
@@ -232,6 +232,8 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
           context
         ) {
           const highestSnapPoint = animatedHighestSnapPoint.value;
+          const isSheetAtHighestSnapPoint =
+            animatedPosition.value === highestSnapPoint;
 
           /**
            * if scrollable is refreshable and sheet position at the highest
@@ -240,7 +242,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
           if (
             source === GESTURE_SOURCE.SCROLLABLE &&
             isScrollableRefreshable.value &&
-            animatedPosition.value === highestSnapPoint
+            isSheetAtHighestSnapPoint
           ) {
             return;
           }
@@ -256,8 +258,8 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
             if (context.initialPosition > animatedPosition.value) {
               animateToPosition(
                 context.initialPosition,
-                velocityY / 2,
-                ANIMATION_SOURCE.GESTURE
+                ANIMATION_SOURCE.GESTURE,
+                velocityY / 2
               );
             }
             return;
@@ -330,36 +332,20 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
             return;
           }
 
-          /**
-           * if gesture was picked by scrollable and did not move the sheet,
-           * then exit the method to prevent snapping.
-           */
-          if (
-            (source === GESTURE_SOURCE.SCROLLABLE
-              ? animatedScrollableContentOffsetY.value
-              : 0) > 0 &&
-            context.initialPosition === highestSnapPoint &&
-            animatedPosition.value === highestSnapPoint
-          ) {
-            return;
-          }
-
-          /**
-           * if gesture started by scrollable dragging the sheet than continue scrolling,
-           * then exit the method to prevent snapping.
-           */
-          if (
+          const wasGestureHandledByScrollView =
             source === GESTURE_SOURCE.SCROLLABLE &&
-            animatedScrollableContentOffsetY.value > 0 &&
-            animatedPosition.value === highestSnapPoint
-          ) {
+            animatedScrollableContentOffsetY.value > 0;
+          /**
+           * prevents snapping from top to middle / bottom with repeated interrupted scrolls
+           */
+          if (wasGestureHandledByScrollView && isSheetAtHighestSnapPoint) {
             return;
           }
 
           animateToPosition(
             destinationPoint,
-            velocityY / 2,
-            ANIMATION_SOURCE.GESTURE
+            ANIMATION_SOURCE.GESTURE,
+            velocityY / 2
           );
         },
         [


### PR DESCRIPTION
## Motivation

animateToPosition accepts:

```
export type AnimateToPositionType = (
  position: number,
  source: ANIMATION_SOURCE,
  velocity?: number,
  configs?: Animated.WithTimingConfig | Animated.WithSpringConfig
) => void;
```

it was incorrectly called like this `animateToPosition(context.initialPosition, velocityY / 2);` - so `velocityY / 2` was used in place of `ANIMATION_SOURCE` which is an enum.

According to [this SO answer](https://stackoverflow.com/a/57334710/2070942), TS does not distinguish between numbers and numeric Enums, which is why the error came to be in the first place. Let me know if you wanna change the enums to strings, I can add that to this PR (or open a new one).

There is one more change in `src/hooks/useGestureEventsHandlersDefault.tsx` - in this block I removed the first condtion and slightly simplified the second.

In the original code, if you look at the second condition you can see it is the same condition as the first one, just relaxed by the `context.initialPosition === highestSnapPoint` part. That means the second condition is a "superset" of the first and so the first can be removed (I hope I'm not wrong here :D).

```
if (
  (type === GESTURE_SOURCE.SCROLLABLE
    ? animatedScrollableContentOffsetY.value
    : 0) > 0 &&
  context.initialPosition === highestSnapPoint &&
  animatedPosition.value === highestSnapPoint
) {
  return;
}

/**
 * if gesture started by scrollable dragging the sheet than continue scrolling,
 * then exit the method to prevent snapping.
 */
if (
  type === GESTURE_SOURCE.SCROLLABLE &&
  animatedScrollableContentOffsetY.value > 0 &&
  animatedPosition.value === highestSnapPoint
) {
  return;
}
```

Thanks!