### PR TITLE
fix: use correct TS types for style prop

### DIFF
--- a/example/src/Dev.tsx
+++ b/example/src/Dev.tsx
@@ -99,7 +99,7 @@ const App = () => {
           style={styles.flatlist}
           contentContainerStyle={styles.flatlistContainer}
         />
-        <BottomSheetFooter appearanceBehavior={['fade', 'scale']}>
+        <BottomSheetFooter>
           <RectButton style={styles.footer}>
             <Text style={styles.footerText}>this is a footer!</Text>
           </RectButton>

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import type { ViewStyle, Insets } from 'react-native';
+import type { ViewStyle, Insets, StyleProp } from 'react-native';
 import type Animated from 'react-native-reanimated';
 import type { PanGestureHandlerProps } from 'react-native-gesture-handler';
 import type { BottomSheetHandleProps } from '../bottomSheetHandle';
@@ -165,17 +165,19 @@ export interface BottomSheetProps
    * @type Animated.AnimateStyle<ViewStyle>
    * @default undefined
    */
-  style?: Animated.AnimateStyle<
-    Omit<
-      ViewStyle,
-      | 'flexDirection'
-      | 'position'
-      | 'top'
-      | 'left'
-      | 'bottom'
-      | 'right'
-      | 'opacity'
-      | 'transform'
+  style?: StyleProp<
+    Animated.AnimateStyle<
+      Omit<
+        ViewStyle,
+        | 'flexDirection'
+        | 'position'
+        | 'top'
+        | 'left'
+        | 'bottom'
+        | 'right'
+        | 'opacity'
+        | 'transform'
+      >
     >
   >;
   /**
@@ -184,9 +186,8 @@ export interface BottomSheetProps
    * @type ViewStyle
    * @default undefined
    */
-  backgroundStyle?: Omit<
-    ViewStyle,
-    'position' | 'top' | 'left' | 'bottom' | 'right'
+  backgroundStyle?: StyleProp<
+    Omit<ViewStyle, 'position' | 'top' | 'left' | 'bottom' | 'right'>
   >;
   /**
    * View style to be applied to the handle component.
@@ -194,14 +195,14 @@ export interface BottomSheetProps
    * @type ViewStyle
    * @default undefined
    */
-  handleStyle?: ViewStyle;
+  handleStyle?: StyleProp<ViewStyle>;
   /**
    * View style to be applied to the handle indicator component.
    *
    * @type ViewStyle
    * @default undefined
    */
-  handleIndicatorStyle?: ViewStyle;
+  handleIndicatorStyle?: StyleProp<ViewStyle>;
   /**
    * Custom hook to provide pan gesture events handler, which will allow advance and
    * customize handling for pan gesture.

--- a/src/components/bottomSheetHandle/types.d.ts
+++ b/src/components/bottomSheetHandle/types.d.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import type { ViewStyle } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
 import type Animated from 'react-native-reanimated';
 import type { BottomSheetVariables } from '../../types';
 
@@ -11,13 +11,13 @@ export interface BottomSheetDefaultHandleProps extends BottomSheetHandleProps {
    * @type Animated.AnimateStyle<ViewStyle> | ViewStyle
    * @default undefined
    */
-  style?: ViewStyle | Animated.AnimateStyle<ViewStyle>;
+  style?: StyleProp<ViewStyle | Animated.AnimateStyle<ViewStyle>>;
   /**
    * View style to be applied to the handle indicator.
    * @type Animated.AnimateStyle<ViewStyle> | ViewStyle
    * @default undefined
    */
-  indicatorStyle?: ViewStyle | Animated.AnimateStyle<ViewStyle>;
+  indicatorStyle?: StyleProp<ViewStyle | Animated.AnimateStyle<ViewStyle>>;
   /**
    * Content to be added below the indicator.
    * @type React.ReactNode | React.ReactNode[];


### PR DESCRIPTION
## Motivation

The motivation is to be able to pass styles to the bottom sheet components the same way as with other react native components, see eg. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ff070e46d5821d3a28beed3707386677231ce204/types/react-native/index.d.ts#L2919

current situation:

<img width="330" alt="Screen Shot 2021-08-31 at 11 02 28" src="https://user-images.githubusercontent.com/1566403/131474551-7330a265-9b97-4967-ae29-a0c7f359f3ec.png">

<img width="709" alt="Screen Shot 2021-08-31 at 11 03 21" src="https://user-images.githubusercontent.com/1566403/131474689-8ecdce8c-6f70-468c-8b63-115fbadf3916.png">

The second screenshot contains valid styles, but the TS typings currently do not accept them. This change makes it so that the second example is valid too.


also removed `appearanceBehavior` because it does not appear to be used anywhere. Actually, `animatedFooterPosition` should be passed in that place - it'd be good to include some static checks in the repo's pipeline it seems 🙂 