### PR TITLE
fix: remove 'removeListener' as it is now deprecated

### DIFF
--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -86,26 +86,19 @@ export const useKeyboard = () => {
       );
     };
 
-    Keyboard.addListener(
+    const showSubscription = Keyboard.addListener(
       KEYBOARD_EVENT_MAPPER.KEYBOARD_SHOW,
       handleOnKeyboardShow
     );
 
-    Keyboard.addListener(
+    const hideSubscription = Keyboard.addListener(
       KEYBOARD_EVENT_MAPPER.KEYBOARD_HIDE,
       handleOnKeyboardHide
     );
 
     return () => {
-      Keyboard.removeListener(
-        KEYBOARD_EVENT_MAPPER.KEYBOARD_SHOW,
-        handleOnKeyboardShow
-      );
-
-      Keyboard.removeListener(
-        KEYBOARD_EVENT_MAPPER.KEYBOARD_HIDE,
-        handleOnKeyboardHide
-      );
+      showSubscription.remove();
+      hideSubscription.remove();
     };
   }, [handleKeyboardEvent]);
 


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

removeListener is deprecated, and using it at runtime results in a handled exception. Converting to using the remove() method on the EvenSubscription returned from the addListener call eliminates this handled exception.
