### PR TITLE
fix: prevent scrollable content interactions while animating

### DIFF
--- a/src/components/bottomSheetScrollable/BottomSheetScrollableCellRenderer.tsx
+++ b/src/components/bottomSheetScrollable/BottomSheetScrollableCellRenderer.tsx
@@ -1,0 +1,20 @@
+import React, { memo } from 'react';
+import Animated, { useAnimatedProps } from 'react-native-reanimated';
+import { ANIMATION_STATE } from '../../constants';
+import { useBottomSheetInternal } from '../../hooks';
+
+const BottomSheetScrollableCellRendererComponent = (props: any) => {
+  const { animatedAnimationState } = useBottomSheetInternal();
+  const containerAnimatedProps = useAnimatedProps(() => ({
+    pointerEvents:
+      animatedAnimationState.value === ANIMATION_STATE.RUNNING
+        ? 'none'
+        : 'auto',
+  }));
+
+  return <Animated.View animatedProps={containerAnimatedProps} {...props} />;
+};
+
+export const BottomSheetScrollableCellRenderer = memo(
+  BottomSheetScrollableCellRendererComponent
+);

--- a/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
+++ b/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
@@ -4,6 +4,7 @@ import { useAnimatedProps, useAnimatedStyle } from 'react-native-reanimated';
 import { NativeViewGestureHandler } from 'react-native-gesture-handler';
 import BottomSheetDraggableView from '../bottomSheetDraggableView';
 import BottomSheetRefreshControl from '../bottomSheetRefreshControl';
+import { BottomSheetScrollableCellRenderer } from './BottomSheetScrollableCellRenderer';
 import {
   useScrollHandler,
   useScrollableSetter,
@@ -28,6 +29,7 @@ export function createBottomSheetScrollableComponent<T, P>(
       scrollEventsHandlersHook,
       // props
       enableFooterMarginAdjustment = false,
+      enableContentInteractionWhileAnimating = true,
       overScrollMode = 'never',
       keyboardDismissMode = 'interactive',
       showsVerticalScrollIndicator = true,
@@ -115,6 +117,11 @@ export function createBottomSheetScrollableComponent<T, P>(
             keyboardDismissMode={keyboardDismissMode}
             onScroll={scrollHandler}
             style={containerStyle}
+            CellRendererComponent={
+              enableContentInteractionWhileAnimating
+                ? BottomSheetScrollableCellRenderer
+                : undefined
+            }
           />
         </NativeViewGestureHandler>
       );
@@ -163,6 +170,11 @@ export function createBottomSheetScrollableComponent<T, P>(
             refreshControl={refreshControl}
             onScroll={scrollHandler}
             style={containerStyle}
+            CellRendererComponent={
+              enableContentInteractionWhileAnimating
+                ? BottomSheetScrollableCellRenderer
+                : undefined
+            }
           />
         </NativeViewGestureHandler>
       </BottomSheetDraggableView>

--- a/src/components/bottomSheetScrollable/types.d.ts
+++ b/src/components/bottomSheetScrollable/types.d.ts
@@ -29,6 +29,15 @@ export interface BottomSheetScrollableProps {
   enableFooterMarginAdjustment?: boolean;
 
   /**
+   * Allow user to interact with scrollable content
+   * while the sheet is animating.
+   *
+   * @type boolean
+   * @default true
+   */
+  enableContentInteractionWhileAnimating?: boolean;
+
+  /**
    * This needed when bottom sheet used with multiple scrollables to allow bottom sheet
    * detect the current scrollable ref, especially when used with `React Navigation`.
    * You will need to provide `useFocusEffect` from `@react-navigation/native`.


### PR DESCRIPTION
Closes #632 #575

## Motivation

This pr will prevent the scrollable content from interacting while the sheet is animating, this was possible by using `CellRendererComponent` prop and `animatedAnimationState` variable.

## Installation

```bash
yarn add ssh://git@github.com:gorhom/react-native-bottom-sheet#fix/632-prevent-content-interactions-while-animating
```