### PR TITLE
fix(example): replace blacklist with exclusionList

### DIFF
--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-const blacklist = require('metro-config/src/defaults/blacklist');
+const exclusionList = require('metro-config/src/defaults/exclusionList');
 const escape = require('escape-string-regexp');
 
 const root = path.resolve(__dirname, '..');
@@ -21,7 +21,7 @@ module.exports = {
   watchFolders: [root],
 
   resolver: {
-    blacklistRE: blacklist([
+    blacklistRE: exclusionList([
       new RegExp(`^${escape(path.join(root, 'node_modules'))}\\/.*$`),
     ]),
 


### PR DESCRIPTION
## Motivation

The example can't be run

```
yarn start
yarn run v1.22.5
$ react-native start
error Cannot find module 'metro-config/src/defaults/blacklist'
Require stack:
- .\react-native-bottom-sheet\example\metro.config.js
- .\react-native-bottom-sheet\example\node_modules\import-fresh\index.js
- .\react-native-bottom-sheet\example\node_modules\cosmiconfig\dist\loaders.js
- .\react-native-bottom-sheet\example\node_modules\cosmiconfig\dist\createExplorer.js
- .\react-native-bottom-sheet\example\node_modules\cosmiconfig\dist\index.js
- .\react-native-bottom-sheet\example\node_modules\@react-native-community\cli\build\tools\config\readConfigFromDisk.js
- .\react-native-bottom-sheet\example\node_modules\@react-native-community\cli\build\tools\config\index.js
- .\react-native-bottom-sheet\example\node_modules\@react-native-community\cli\build\commands\install\install.js
- .\react-native-bottom-sheet\example\node_modules\@react-native-community\cli\build\commands\index.js
- .\react-native-bottom-sheet\example\node_modules\@react-native-community\cli\build\index.js
- .\react-native-bottom-sheet\example\node_modules\react-native\cli.js.
Error: Cannot find module 'metro-config/src/defaults/blacklist'
Require stack:
- .\react-native-bottom-sheet\example\metro.config.js
- .\react-native-bottom-sheet\example\node_modules\import-fresh\index.js
- .\react-native-bottom-sheet\example\node_modules\cosmiconfig\dist\loaders.js
- .\react-native-bottom-sheet\example\node_modules\cosmiconfig\dist\createExplorer.js
- .\react-native-bottom-sheet\example\node_modules\cosmiconfig\dist\index.js
- .\react-native-bottom-sheet\example\node_modules\@react-native-community\cli\build\tools\config\readConfigFromDisk.js
- .\react-native-bottom-sheet\example\node_modules\@react-native-community\cli\build\tools\config\index.js
- .\react-native-bottom-sheet\example\node_modules\@react-native-community\cli\build\commands\install\install.js
- .\react-native-bottom-sheet\example\node_modules\@react-native-community\cli\build\commands\index.js
- .\react-native-bottom-sheet\example\node_modules\@react-native-community\cli\build\index.js
- .\react-native-bottom-sheet\example\node_modules\react-native\cli.js
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:941:15)
    at Function.Module._load (node:internal/modules/cjs/loader:774:27)
    at Module.require (node:internal/modules/cjs/loader:1013:19)
    at require (node:internal/modules/cjs/helpers:93:18)
    at Object.<anonymous> (.\react-native-bottom-sheet\example\metro.config.js:3:19)
    at Module._compile (node:internal/modules/cjs/loader:1109:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1138:10)
    at Module.load (node:internal/modules/cjs/loader:989:32)
    at Function.Module._load (node:internal/modules/cjs/loader:829:14)
    at Module.require (node:internal/modules/cjs/loader:1013:19)
info Run CLI with --verbose flag for more details.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
