### PR TITLE
Make bottom sheet fixed on web

### DIFF
--- a/src/components/bottomSheet/styles.web.ts
+++ b/src/components/bottomSheet/styles.web.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'column-reverse',
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+  },
+  contentContainer: {},
+  contentMaskContainer: {
+    overflow: 'hidden',
+  },
+});


### PR DESCRIPTION

Please provide enough information so that others can review your pull request:

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

The bottom sheet is actually stuck at the top of the page when scrolling on web, this PR make it fixed so it stay on the screen.

I was unable to fix the backdrop the same way (probably because of reanimated view, so i did wrap it in a view:

```javascript

  
  const renderBackdrop = useCallback(
    props => (
      <View style={Platform.select({
          web: {
            position: 'fixed',
            bottom: 0,
            left: 0,
            right: 0,
            top: 0
          },
          default: {}
        })}>
        <BottomSheetBackdrop
          disappearsOnIndex={-1}
          appearsOnIndex={0}
          {...props}
        />
      </View>
    ),
    []
  );
```