### PR TITLE
React on keyboard height change

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1333,8 +1333,15 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
      * @alias OnKeyboardStateChange
      */
     useAnimatedReaction(
-      () => animatedKeyboardState.value,
-      (_keyboardState, _previousKeyboardState) => {
+      () => ({
+        _keyboardState: animatedKeyboardState.value,
+        _keyboardHeight: animatedKeyboardHeight.value,
+      }),
+      (result, previousResult) => {
+        const { _keyboardState, _keyboardHeight } = result;
+        const { _keyboardState: _previousKeyboardState,
+          _keyboardHeight: _previousKeyboardHeight } = previousResult;
+
         const hasActiveGesture =
           animatedContentGestureState.value === State.ACTIVE ||
           animatedContentGestureState.value === State.BEGAN ||
@@ -1345,7 +1352,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           /**
            * if keyboard state is equal to the previous state, then exit the method
            */
-          _keyboardState === _previousKeyboardState ||
+          (_keyboardState === _previousKeyboardState &&
+            _keyboardHeight === _previousKeyboardHeight) ||
           /**
            * if user is interacting with sheet, then exit the method
            */
@@ -1374,6 +1382,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           method: 'useAnimatedReaction::OnKeyboardStateChange',
           params: {
             keyboardState: _keyboardState,
+            keyboardHeight: _keyboardHeight,
           },
         });
 

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1337,10 +1337,10 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         _keyboardState: animatedKeyboardState.value,
         _keyboardHeight: animatedKeyboardHeight.value,
       }),
-      (result, previousResult) => {
+      (result, _previousResult) => {
         const { _keyboardState, _keyboardHeight } = result;
-        const { _keyboardState: _previousKeyboardState,
-          _keyboardHeight: _previousKeyboardHeight } = previousResult;
+        const _previousKeyboardState = _previousResult?._keyboardState;
+        const _previousKeyboardHeight = _previousResult?._keyboardHeight;
 
         const hasActiveGesture =
           animatedContentGestureState.value === State.ACTIVE ||


### PR DESCRIPTION
Resolves #655

Keyboard state property changes only when the keyboard is opened or closed. But it does not react to changes that happen when the keyboard is already open. An example of such change is switch keyboard layout, or opening the emoji keyboard.

## Motivation

By reacting to height change we solve the issue when the keyboard changes the height from a smaller to a bigger one. In such cases, the keyboard covers the content disallowing the user to interact with that part of the bottom sheet.

