### PR TITLE
feat: dismiss() without a key will remove the current modal if any

### DIFF
--- a/src/components/bottomSheetModalProvider/BottomSheetModalProvider.tsx
+++ b/src/components/bottomSheetModalProvider/BottomSheetModalProvider.tsx
@@ -135,13 +135,15 @@ const BottomSheetModalProviderWrapper = ({
   //#endregion
 
   //#region public methods
-  const handleDismiss = useCallback((key: string) => {
-    const sheetToBeDismissed = sheetsQueueRef.current.find(
-      item => item.key === key
-    );
+  const handleDismiss = useCallback((key?: string) => {
+    const sheetToBeDismissed = key
+      ? sheetsQueueRef.current.find(item => item.key === key)
+      : sheetsQueueRef.current[sheetsQueueRef.current.length - 1];
     if (sheetToBeDismissed) {
       sheetToBeDismissed.ref.current.dismiss();
+      return true;
     }
+    return false;
   }, []);
   const handleDismissAll = useCallback(() => {
     sheetsQueueRef.current.map(item => {

--- a/src/contexts/modal/external.ts
+++ b/src/contexts/modal/external.ts
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 
 export interface BottomSheetModalContextType {
-  dismiss: (key: string) => void;
+  dismiss: (key?: string) => boolean;
   dismissAll: () => void;
 }
 


### PR DESCRIPTION
## Motivation

This enable calling `dismiss` from `useBottomSheetModal` without passing any key, so it can remove the currently presented `BottomSheetModal`, if any. It also now returns a boolean indicating whether a `BottomSheetModal` has been dismissed.

This enable users of this to call `dismiss` without having to manage themselves which modal is currently presented and can lead to a more straightforward usage of back handler on Android in most use-cases, for example :

```ts
const { dismiss } = useBottomSheetModal()
useBackHandler(dismiss)
```

