### PR TITLE
fix: hide the sheet container on closed

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1147,13 +1147,17 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     //#endregion
 
     //#region styles
-    const containerAnimatedStyle = useAnimatedStyle(() => ({
-      transform: [
-        {
-          translateY: animatedPosition.value,
-        },
-      ],
-    }));
+    const containerAnimatedStyle = useAnimatedStyle(
+      () => ({
+        opacity: animatedIndex.value === -1 ? 0 : 1,
+        transform: [
+          {
+            translateY: animatedPosition.value,
+          },
+        ],
+      }),
+      [animatedPosition, animatedIndex]
+    );
     const containerStyle = useMemo(
       () => [_providedStyle, styles.container, containerAnimatedStyle],
       [_providedStyle, containerAnimatedStyle]


### PR DESCRIPTION
Closes #665

## Motivation

When the user dismiss a keyboard view on Android, the container height will resize after the keyboard is been hidden, which will make the closed bottom sheet visible for few milliseconds. 

So i have added a logic to hide the bottom sheet when it is closed.

## Installation

```bash
yarn add ssh://git@github.com:gorhom/react-native-bottom-sheet#fix/665-hide-sheet-when-closed
```