### PR TITLE
feat: Add prop minDist for BottomSheet

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -136,6 +136,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       activeOffsetY: _providedActiveOffsetY,
       failOffsetX: _providedFailOffsetX,
       failOffsetY: _providedFailOffsetY,
+      minDist: _providedMinDist,
 
       // callbacks
       onChange: _providedOnChange,
@@ -1075,6 +1076,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         activeOffsetY: _providedActiveOffsetY,
         failOffsetX: _providedFailOffsetX,
         failOffsetY: _providedFailOffsetY,
+        minDist: _providedMinDist,
         animateToPosition,
         stopAnimation,
         getKeyboardHeightInContainer,
@@ -1115,6 +1117,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         _providedActiveOffsetY,
         _providedFailOffsetX,
         _providedFailOffsetY,
+        _providedMinDist,
         getKeyboardHeightInContainer,
         setScrollableRef,
         removeScrollableRef,

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -25,6 +25,7 @@ export interface BottomSheetProps
         | 'failOffsetX'
         | 'waitFor'
         | 'simultaneousHandlers'
+        | 'minDist'
       >
     > {
   //#region configuration

--- a/src/components/bottomSheetDraggableView/BottomSheetDraggableView.tsx
+++ b/src/components/bottomSheetDraggableView/BottomSheetDraggableView.tsx
@@ -27,6 +27,7 @@ const BottomSheetDraggableViewComponent = ({
     activeOffsetY,
     failOffsetX,
     failOffsetY,
+    minDist,
   } = useBottomSheetInternal();
   const { contentPanGestureHandler } = useBottomSheetGestureHandlers();
 
@@ -82,6 +83,7 @@ const BottomSheetDraggableViewComponent = ({
       activeOffsetY={activeOffsetY}
       failOffsetX={failOffsetX}
       failOffsetY={failOffsetY}
+      minDist={minDist}
     >
       <Animated.View style={containerStyle} {...rest}>
         {children}

--- a/src/contexts/internal.ts
+++ b/src/contexts/internal.ts
@@ -26,6 +26,7 @@ export interface BottomSheetInternalContextType
       | 'failOffsetX'
       | 'waitFor'
       | 'simultaneousHandlers'
+      | 'minDist'
     >,
     Required<
       Pick<


### PR DESCRIPTION
## Motivation

On screen where I'm use bottom sheet modal, gesture for back navigation is blocked in over 80% of attempts, because modal intercepts event. I sure that minDist will fix it:)
