### PR TITLE
Opacity animation through withTiming with 0 duration

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -19,6 +19,7 @@ import Animated, {
   runOnUI,
   cancelAnimation,
   useWorkletCallback,
+  withTiming
 } from 'react-native-reanimated';
 import { State } from 'react-native-gesture-handler';
 import {
@@ -1149,6 +1150,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     //#region styles
     const containerAnimatedStyle = useAnimatedStyle(
       () => ({
+        opacity: withTiming(animatedIndex.value === -1 ? 0 : 1, {duration: 0}),
         transform: [
           {
             translateY: animatedPosition.value,

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1149,7 +1149,6 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     //#region styles
     const containerAnimatedStyle = useAnimatedStyle(
       () => ({
-        opacity: animatedIndex.value === -1 ? 0 : 1,
         transform: [
           {
             translateY: animatedPosition.value,


### PR DESCRIPTION
This explores solving issue: #719

Presently when toggling a modal the containerAnimatedStyle is setting opacity based on the animatedIndex value. Occasionally, and seemingly randomly, this fails and leaves the opacity set to 0, even if the modal is open. 

I don't have enough of an understanding of all the use cases to say whether this change breaks anything else but removing the opacity toggle entirely results in no observable problems and issue #719 no longer occurs.

If we did want to animate the opacity something like:
`opacity: interpolate(animatedIndex.value, [-1, 0], [0, 1])`

Would likely be more appropriate but in observing that it doesn't look desirable, but least works reliably.

This could be a short term patch for people having the same issue as us until someone with more experience on the project can advise.



