### PR TITLE
fix: screen reader not working in sheet on ios

### DIFF
--- a/src/components/bottomSheetContentWrapper/BottomSheetContentWrapper.ios.tsx
+++ b/src/components/bottomSheetContentWrapper/BottomSheetContentWrapper.ios.tsx
@@ -3,11 +3,14 @@ import isEqual from 'lodash.isequal';
 import { TapGestureHandler } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
 import type { BottomSheetContentWrapperProps } from './types';
+import { useScreenReader } from '../../hooks/useScreenReader';
 
 const BottomSheetContentWrapperComponent = forwardRef<
   TapGestureHandler,
   BottomSheetContentWrapperProps
 >(({ children, onGestureEvent, onHandlerStateChange }, ref) => {
+  const { isScreenReaderEnabled } = useScreenReader();
+
   return (
     <TapGestureHandler
       ref={ref}
@@ -16,7 +19,11 @@ const BottomSheetContentWrapperComponent = forwardRef<
       onGestureEvent={onGestureEvent}
       onHandlerStateChange={onHandlerStateChange}
     >
-      <Animated.View pointerEvents="box-none">{children}</Animated.View>
+      {isScreenReaderEnabled ? (
+        children
+      ) : (
+        <Animated.View pointerEvents="box-none">{children}</Animated.View>
+      )}
     </TapGestureHandler>
   );
 });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,6 +4,7 @@ export { useScrollableInternal } from './useScrollableInternal';
 export { useStableCallback } from './useStableCallback';
 export { useNormalizedSnapPoints } from './useNormalizedSnapPoints';
 export { usePropsValidator } from './usePropsValidator';
+export { useScreenReader } from './useScreenReader';
 
 // reactive value/s
 export { useReactiveValue } from './useReactiveValue';

--- a/src/hooks/useScreenReader.ts
+++ b/src/hooks/useScreenReader.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { AccessibilityEvent, AccessibilityInfo } from 'react-native';
+
+export const useScreenReader = () => {
+  const [isScreenReaderEnabled, setIsScreenReaderEnabled] = useState<boolean>();
+
+  useEffect(() => {
+    const handleScreenReaderChanged = (event: AccessibilityEvent) => {
+      setIsScreenReaderEnabled(event as boolean);
+    };
+
+    // sets initial screenReader value
+    AccessibilityInfo.isScreenReaderEnabled().then(setIsScreenReaderEnabled);
+
+    AccessibilityInfo.addEventListener(
+      'screenReaderChanged',
+      handleScreenReaderChanged
+    );
+
+    return () => {
+      AccessibilityInfo.removeEventListener(
+        'screenReaderChanged',
+        handleScreenReaderChanged
+      );
+    };
+  }, []);
+
+  return { isScreenReaderEnabled };
+};


### PR DESCRIPTION
## Motivation

While using a screen reader on iOS it is not possible to move focus inside the sheet. This PR fixes the problem by removing an Animated.View (which caused the problem) inside BottomSheetContentWrapper if screen reader is enabled.