### PR TITLE
feat: support Android elevation for BottomSheet component

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -124,6 +124,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       containerOffset: _providedContainerOffset,
       topInset = 0,
       bottomInset = 0,
+      elevation = 0,
 
       // animated callback shared values
       animatedPosition: _providedAnimatedPosition,
@@ -1566,6 +1567,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
               topInset={topInset}
               bottomInset={bottomInset}
               detached={detached}
+              elevation={elevation}
             >
               <Animated.View style={containerStyle}>
                 <BottomSheetBackgroundContainer

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -130,6 +130,12 @@ export interface BottomSheetProps
    * @default 0
    */
   bottomInset?: number;
+  /**
+   * Enable elevation on bottom sheet container.
+   * @type number
+   * @default 0
+   */
+  elevation?: number;
   //#endregion
 
   //#region keyboard

--- a/src/components/bottomSheetContainer/BottomSheetContainer.tsx
+++ b/src/components/bottomSheetContainer/BottomSheetContainer.tsx
@@ -12,6 +12,7 @@ function BottomSheetContainerComponent({
   bottomInset = 0,
   shouldCalculateHeight = true,
   detached,
+  elevation = 0,
   children,
 }: BottomSheetContainerProps) {
   const containerRef = useRef<View>(null);
@@ -23,9 +24,10 @@ function BottomSheetContainerComponent({
         top: topInset,
         bottom: bottomInset,
         overflow: detached ? 'visible' : 'hidden',
+        elevation,
       },
     ],
-    [detached, topInset, bottomInset]
+    [detached, topInset, bottomInset, elevation]
   );
   //#endregion
 

--- a/src/components/bottomSheetContainer/types.d.ts
+++ b/src/components/bottomSheetContainer/types.d.ts
@@ -5,7 +5,10 @@ import type { BottomSheetProps } from '../bottomSheet/types';
 
 export interface BottomSheetContainerProps
   extends Partial<
-    Pick<BottomSheetProps, 'topInset' | 'bottomInset' | 'detached'>
+    Pick<
+      BottomSheetProps,
+      'topInset' | 'bottomInset' | 'detached' | 'elevation'
+    >
   > {
   containerHeight: Animated.SharedValue<number>;
   containerOffset: Animated.SharedValue<Insets>;


### PR DESCRIPTION
## Motivation

When rendering a component in the top portion of the screen (i.e. outside of the `BottomSheet` component), if this or any child components include an `elevation` style property, they are rendered on top of the bottom sheet. This is concisely described in #387 and #692.

A fix was proposed in #398 but was closed due to not adhering to the issue template. The bulk of the changes in this PR follow this proposal: an `elevation` prop has been added to the `BottomSheet` component, allowing it to be elevated above any other component that may otherwise render on top of the sheet.

