### PR TITLE
fix: Cannot find module 'metro-config/src/defaults/blacklist' in the example

### DIFF
--- a/example/metro.config.js
+++ b/example/metro.config.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-const blacklist = require('metro-config/src/defaults/blacklist');
+const blacklist = require('metro-config/src/defaults/exclusionList');
 const escape = require('escape-string-regexp');
 
 const root = path.resolve(__dirname, '..');


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18282328/141679177-f73806d5-26ad-4070-9d9e-8676ad201466.png)