### PR TITLE
Use padding to define the paddingBottom

### DIFF
--- a/src/components/bottomSheetView/BottomSheetView.tsx
+++ b/src/components/bottomSheetView/BottomSheetView.tsx
@@ -25,7 +25,9 @@ function BottomSheetViewComponent({
     const paddingBottom =
       flattenStyle && 'paddingBottom' in flattenStyle
         ? flattenStyle.paddingBottom
-        : 0;
+        : flattenStyle && 'padding' in flattenStyle
+          ? flattenStyle.padding
+          : 0;
     return typeof paddingBottom === 'number' ? paddingBottom : 0;
   }, [style]);
   const containerAnimatedStyle = useAnimatedStyle(


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Change bottom padding of the `<BottomSheetView />` component to also take into consideration the `padding` style prop.

Fixes: #791 

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

padding style property is not affecting bottom side of the `<BottomSheetView />` component.
Bottom padding is only changed when using `paddingBottom: x` style prop.

This PR fixes this issue.