### PR TITLE
Adjust closed position if container height changes on Android

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1286,6 +1286,14 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           !isLayoutCalculated.value ||
           !isAnimatedOnMount.value
         ) {
+          if (
+            Platform.OS === 'android' &&
+            keyboardBehavior === KEYBOARD_BEHAVIOR.interactive &&
+            android_keyboardInputMode === KEYBOARD_INPUT_MODE.adjustResize &&
+            animatedPosition.value === _previousContainerHeight
+          ) {
+            animatedPosition.value = containerHeight;
+          }
           return;
         }
 


### PR DESCRIPTION
## Motivation

On Android if you have a tall bottom sheet present but closed, then open the full keyboard, then select the options and one handed keyboard, the keyboard shrinks. This will then expose the handle of the hidden tall bottom sheet. It appears this is because the `animatedPosition` remains unchanged despite the keyboard shrinking and the `snapPoints` are unchanged `[0]`. Piggybacking on this `animatedReaction` we can check if the current `animatedPosition` is the same as the `_previousContainerHeight` then adjust the position to the new `containerHeight`. This solves the issue, I believe there will be no side effects as the additional checks keep this reassignment from occurring when other functions could change the `animatedPosition` value. 