### PR TITLE
Trigger onAnimate even when animatedCurrentIndex doesn't change

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -608,9 +608,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           return;
         }
 
-        if (toIndex !== animatedCurrentIndex.value) {
-          _providedOnAnimate(animatedCurrentIndex.value, toIndex);
-        }
+        _providedOnAnimate(animatedCurrentIndex.value, toIndex);
       },
       [_providedOnAnimate, animatedSnapPoints, animatedCurrentIndex]
     );


### PR DESCRIPTION
## Motivation

onAnimate currently trigger only when animatedCurrentIndex is different than the target index, this is fine, however, triggering this callback when the the bottom sheet doesn't snap to a new position is useful, in my case I wanted to implement pull to refresh for the entire bottom sheet (not just scrollables inside) so this change was very helpful. 

I can just compare the callback props (fromIndex, toIndex) and see wether I should trigger a refresh or not
I'm new to contribution for this awesome package so let me know if I'm missing something here! Thank you 

Side Note: I came to this solution because I had trouble accessing onEndDrag event for example but I see this solution easier.