### PR TITLE
fix: Always update height to avoid races.

### DIFF
--- a/src/components/bottomSheetContainer/BottomSheetContainer.tsx
+++ b/src/components/bottomSheetContainer/BottomSheetContainer.tsx
@@ -36,9 +36,7 @@ function BottomSheetContainerComponent({
         layout: { height },
       },
     }: LayoutChangeEvent) {
-      if (height !== containerHeight.value) {
-        containerHeight.value = height;
-      }
+      containerHeight.value = height;
 
       containerRef.current?.measure(
         (_x, _y, _width, _height, _pageX, pageY) => {


### PR DESCRIPTION
Updating a shared values is an asynchronous operation, so if two layouts happen in quick succession, we can miss an update.

Please provide enough information so that others can review your pull request:

## Motivation

On iOS devices, when backgrounding an app, the OS takes two screenshots (normal, and then rotated) so it can display thumbnail in the app switcher regardless of orientation. Apps see a rather confusing success of two screen rotations (and thus layouts).

What would happen is in some cases (it's a race), the container height would end up changing only once to the landscape height, so when you foregrounded the app again your displayed sheet would suddenly be cropped.

So here's the sheet showing properly (full screen player in Plexamp):

![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-04-20 at 10 59 40](https://user-images.githubusercontent.com/10298/164321909-31568e72-eb26-4e36-a26c-2518b90775ec.png)

After backgrounding and foregrounding, and missing a change to the shared value:

![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-04-20 at 11 00 11](https://user-images.githubusercontent.com/10298/164321976-3f2b277b-8c99-4212-b25e-62c22cf9b126.png)

