### PR TITLE
refactor: expose animateOnMount for modals

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -44,6 +44,7 @@ const BottomSheetModalComponent = forwardRef<
     index = 0,
     snapPoints,
     enablePanDownToClose = true,
+    animateOnMount = true,
 
     // callbacks
     onChange: _providedOnChange,
@@ -70,7 +71,7 @@ const BottomSheetModalComponent = forwardRef<
 
   //#region refs
   const bottomSheetRef = useRef<BottomSheet>(null);
-  const currentIndexRef = useRef(-1);
+  const currentIndexRef = useRef(!animateOnMount ? index : -1);
   const restoreIndexRef = useRef(-1);
   const minimized = useRef(false);
   const forcedDismissed = useRef(false);
@@ -375,6 +376,7 @@ const BottomSheetModalComponent = forwardRef<
         index={index}
         snapPoints={snapPoints}
         enablePanDownToClose={enablePanDownToClose}
+        animateOnMount={animateOnMount}
         containerHeight={containerHeight}
         containerOffset={containerOffset}
         onChange={handleBottomSheetOnChange}

--- a/src/components/bottomSheetModal/types.d.ts
+++ b/src/components/bottomSheetModal/types.d.ts
@@ -11,10 +11,7 @@ export interface BottomSheetModalPrivateMethods {
 export type BottomSheetModalStackBehavior = keyof typeof MODAL_STACK_BEHAVIOR;
 
 export interface BottomSheetModalProps
-  extends Omit<
-    BottomSheetProps,
-    'animateOnMount' | 'containerHeight' | 'onClose'
-  > {
+  extends Omit<BottomSheetProps, 'containerHeight' | 'onClose'> {
   /**
    * Modal name to help identify the modal for later on.
    * @type string


### PR DESCRIPTION
Closes #915 

## Motivation

This PR will allow users to set `animateOnMount` modals which makes mounting the bottom sheet instantly 
