### PR TITLE
Allow "pressBehavior" to accept a function

### DIFF
--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -58,6 +58,8 @@ const BottomSheetBackdropComponent = ({
       snapToIndex(disappearsOnIndex as number);
     } else if (typeof pressBehavior === 'number') {
       snapToIndex(pressBehavior);
+    } else if (typeof pressBehavior === 'function') {
+      runOnJS(pressBehavior)()
     }
   }, [snapToIndex, close, disappearsOnIndex, pressBehavior]);
   const handleContainerTouchability = useCallback(


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

If the default BottomSheetBackdrop component, with pressBehavior 'close', is pressed before the BottomSheet is fully opened, "onAnimate" and "onChange" events are not fired. Anyone could have some context variables that changes when the state of the sheet change, and in this particular case I can only use the onClose event to detect the immediate closing of the sheet, losing a lot of performance.

In this way I can pass a function to the pressBehavior, making the setState and the close (triggered in my app with ref.current.close) events synchronized.