### PR TITLE
docs: Update getting-started.mdx

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -61,8 +61,14 @@ This library needs these dependencies to be installed in your project before you
 yarn add react-native-reanimated react-native-gesture-handler
 ```
 
+Using Expo?
+
+```bash
+expo install react-native-reanimated react-native-gesture-handler
+```
+
 :::info
-**React Native Gesture Handler** needs extra steps to finalize its installation, please follow their [installation instructions](https://github.com/software-mansion/react-native-gesture-handler).
+**React Native Gesture Handler** needs extra steps to finalize its installation, please follow their [installation instructions](https://docs.swmansion.com/react-native-gesture-handler/docs/installation). Please **make sure** to wrap your App with `GestureHandlerRootView` when you've upgraded to React Native Gesture Handler ^2.
 
 **React Native Reanimated v2** needs extra steps to finalize its installation, please follow their [installation instructions](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation).
 :::


### PR DESCRIPTION
## Motivation

People still missing the fact that they have to wrap their app with a `GestureHandlerRootVIew` if upgraded to RNGH v2.
Let's just make it more obvious.