### PR TITLE
feat: expose useScrollEventsHandlersDefault

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -8,6 +8,7 @@ export { useBottomSheetModalInternal } from './useBottomSheetModalInternal';
 // scrollable
 export { useScrollable } from './useScrollable';
 export { useScrollableSetter } from './useScrollableSetter';
+export { useScrollEventsHandlersDefault } from './useScrollEventsHandlersDefault';
 export { useScrollHandler } from './useScrollHandler';
 
 // gestures

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export { useBottomSheetTimingConfigs } from './hooks/useBottomSheetTimingConfigs
 export { useBottomSheetInternal } from './hooks/useBottomSheetInternal';
 export { useBottomSheetModalInternal } from './hooks/useBottomSheetModalInternal';
 export { useBottomSheetDynamicSnapPoints } from './hooks/useBottomSheetDynamicSnapPoints';
+export { useScrollEventsHandlersDefault } from './hooks/useScrollEventsHandlersDefault';
 //#endregion
 
 //#region components


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

Exposing useScrollEventsHandlersDefault will make it way easier to modify the behaviour of react-native-bottom-sheet scroll handlers, when you need to perform additional actions, after the default ones are done, without fully rewriting them from scratch

