### PR TITLE
Fix race condition when unmounting modal while opening it

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -73,6 +73,7 @@ const BottomSheetModalComponent = forwardRef<
   const bottomSheetRef = useRef<BottomSheet>(null);
   const currentIndexRef = useRef(!animateOnMount ? index : -1);
   const restoreIndexRef = useRef(-1);
+  const animatingInRef = useRef(!animateOnMount);
   const minimized = useRef(false);
   const forcedDismissed = useRef(false);
   const mounted = useRef(false);
@@ -276,7 +277,11 @@ const BottomSheetModalComponent = forwardRef<
       /**
        * if modal is already been dismiss, we exit the method.
        */
-      if (currentIndexRef.current === -1 && minimized.current === false) {
+      if (
+        currentIndexRef.current === -1 &&
+        minimized.current === false &&
+        !animatingInRef.current
+      ) {
         return;
       }
 
@@ -311,6 +316,7 @@ const BottomSheetModalComponent = forwardRef<
         },
       });
       currentIndexRef.current = _index;
+      animatingInRef.current = false;
 
       if (_providedOnChange) {
         _providedOnChange(_index);

--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -48,6 +48,7 @@ const BottomSheetModalComponent = forwardRef<
 
     // callbacks
     onChange: _providedOnChange,
+    onAnimate: _providedOnAnimate,
 
     // components
     children: Content,
@@ -73,7 +74,7 @@ const BottomSheetModalComponent = forwardRef<
   const bottomSheetRef = useRef<BottomSheet>(null);
   const currentIndexRef = useRef(!animateOnMount ? index : -1);
   const restoreIndexRef = useRef(-1);
-  const animatingInRef = useRef(!animateOnMount);
+  const animatingRef = useRef(!animateOnMount);
   const minimized = useRef(false);
   const forcedDismissed = useRef(false);
   const mounted = useRef(false);
@@ -201,7 +202,11 @@ const BottomSheetModalComponent = forwardRef<
       /**
        * if modal is already been dismiss, we exit the method.
        */
-      if (currentIndexRef.current === -1 && minimized.current === false) {
+       if (
+        currentIndexRef.current === -1 &&
+        minimized.current === false &&
+        !animatingRef.current
+      ) {
         return;
       }
 
@@ -280,7 +285,7 @@ const BottomSheetModalComponent = forwardRef<
       if (
         currentIndexRef.current === -1 &&
         minimized.current === false &&
-        !animatingInRef.current
+        !animatingRef.current
       ) {
         return;
       }
@@ -305,6 +310,19 @@ const BottomSheetModalComponent = forwardRef<
     }
   },
   []);
+  const handleBottomSheetOnAnimate = useCallback(
+    function handleBottomSheetOnAnimate(
+      _fromIndex: number,
+      _toIndex: number,
+    ) {
+      animatingRef.current = true;
+
+      if (_providedOnAnimate) {
+        _providedOnAnimate(_fromIndex, _toIndex);
+      }
+    },
+    [_providedOnAnimate]
+  );
   const handleBottomSheetOnChange = useCallback(
     function handleBottomSheetOnChange(_index: number) {
       print({
@@ -316,7 +334,7 @@ const BottomSheetModalComponent = forwardRef<
         },
       });
       currentIndexRef.current = _index;
-      animatingInRef.current = false;
+      animatingRef.current = false;
 
       if (_providedOnChange) {
         _providedOnChange(_index);
@@ -387,6 +405,7 @@ const BottomSheetModalComponent = forwardRef<
         containerOffset={containerOffset}
         onChange={handleBottomSheetOnChange}
         onClose={handleBottomSheetOnClose}
+        onAnimate={handleBottomSheetOnAnimate}
         children={
           typeof Content === 'function' ? <Content data={data} /> : Content
         }


### PR DESCRIPTION
## Motivation

When a Bottom Sheet is animating in, its currentIndexRef is `-1`, and is not set to `0` until the animation finishes. This means that if the component is unmounted while it's still opening, the modal sticks around on screen and is uncloseable. This results in a zombie bottom sheet modal that can never be removed!  🧟

## To replicate:

```tsx
  const [showModal, setShowModal] = useState(false);
  useEffect(() => {
    setShowModal(true);
    setTimeout(() => {
      setShowModal(false);
    }, 200);
  }, []);

...

{showModal && <BottomSheetPullUp />}
```

## Changes:
- adds an `animatingRef` which tracks the status of the component's entry animation. 
- checks this `animatingRef` when minimizing the modal
- `animatingRef` is initialized as false `animateOnMount` is set to false!
- uses `onAnimate` to set `animatingRef = true` when animating