### PR TITLE
CustomBackdrop starts at -1 through to 0

### DIFF
--- a/docs/guides/custom-backdrop.mdx
+++ b/docs/guides/custom-backdrop.mdx
@@ -50,7 +50,7 @@ const CustomBackdrop = ({ animatedIndex, style }: BottomSheetBackdropProps) => {
   const containerAnimatedStyle = useAnimatedStyle(() => ({
     opacity: interpolate(
       animatedIndex.value,
-      [0, 1],
+      [-1, 0],
       [0, 1],
       Extrapolate.CLAMP
     ),


### PR DESCRIPTION
The example code as it is currently doesn't seem to work. It looks like the animatedIndex.value starts at -1 and moves to 0.

Please provide enough information so that others can review your pull request:

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

