### PR TITLE
fix(regression): updated keyboard handling reaction (by @yusufyildirim)

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1379,6 +1379,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       () => ({
         _keyboardState: animatedKeyboardState.value,
         _keyboardHeight: animatedKeyboardHeight.value,
+        _animatedKeyboardHeightInContainer:
+          animatedKeyboardHeightInContainer.value,
       }),
       (result, _previousResult) => {
         const { _keyboardState, _keyboardHeight } = result;

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -291,36 +291,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       animationEasing: keyboardAnimationEasing,
       shouldHandleKeyboardEvents,
     } = useKeyboard();
-    /**
-     * Returns keyboard height that in the root container.
-     */
-    const animatedKeyboardHeightInContainer = useDerivedValue(() => {
-      /**
-       * if android software input mode is not `adjustPan`, than keyboard
-       * height will be 0 all the time.
-       */
-      if (
-        Platform.OS === 'android' &&
-        android_keyboardInputMode === KEYBOARD_INPUT_MODE.adjustResize
-      ) {
-        return 0;
-      }
-
-      return $modal
-        ? Math.abs(
-            animatedKeyboardHeight.value -
-              Math.abs(bottomInset - animatedContainerOffset.value.bottom)
-          )
-        : Math.abs(
-            animatedKeyboardHeight.value - animatedContainerOffset.value.bottom
-          );
-    }, [
-      $modal,
-      android_keyboardInputMode,
-      bottomInset,
-      animatedKeyboardHeight,
-      animatedContainerOffset,
-    ]);
+    const animatedKeyboardHeightInContainer = useSharedValue(0);
     //#endregion
 
     //#region state/dynamic variables
@@ -1379,13 +1350,21 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       () => ({
         _keyboardState: animatedKeyboardState.value,
         _keyboardHeight: animatedKeyboardHeight.value,
-        _animatedKeyboardHeightInContainer:
-          animatedKeyboardHeightInContainer.value,
       }),
       (result, _previousResult) => {
         const { _keyboardState, _keyboardHeight } = result;
         const _previousKeyboardState = _previousResult?._keyboardState;
         const _previousKeyboardHeight = _previousResult?._keyboardHeight;
+
+        /**
+         * Calculate the keyboard height in the container.
+         */
+        animatedKeyboardHeightInContainer.value = $modal
+          ? Math.abs(
+              _keyboardHeight -
+                Math.abs(bottomInset - animatedContainerOffset.value.bottom)
+            )
+          : Math.abs(_keyboardHeight - animatedContainerOffset.value.bottom);
 
         const hasActiveGesture =
           animatedContentGestureState.value === State.ACTIVE ||
@@ -1419,6 +1398,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
             keyboardBehavior === KEYBOARD_BEHAVIOR.interactive &&
             android_keyboardInputMode === KEYBOARD_INPUT_MODE.adjustResize)
         ) {
+          animatedKeyboardHeightInContainer.value = 0;
           return;
         }
 
@@ -1444,9 +1424,12 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         );
       },
       [
+        $modal,
+        bottomInset,
         keyboardBehavior,
         keyboardBlurBehavior,
         android_keyboardInputMode,
+        animatedContainerOffset,
         getNextPosition,
       ]
     );


### PR DESCRIPTION
This PR fixes #946.

## Motivation

Looks like a regression is introduced with the PR https://github.com/gorhom/react-native-bottom-sheet/pull/931. With that PR, `getKeyboardHeightInContainer` renamed to `animatedKeyboardHeightInContainer` and started using `useDerivedValue` instead of `useWorkletCallback` which made it a `SharedValue` instead of a `function` to fix another bug. Yet introduced #946, a tricky bug. Here's the screen recording:

https://user-images.githubusercontent.com/22980987/172833171-beca69c8-2b15-4428-8aff-6e14465b9205.mov

Here's where I placed the `console.log`s to debug:

* Input focused: https://github.com/yusufyildirim/react-native-bottom-sheet/blob/fix/keyboard-handling/src/components/bottomSheetTextInput/BottomSheetTextInput.tsx#L17
* Keyboard Height Changed: https://github.com/yusufyildirim/react-native-bottom-sheet/blob/fix/keyboard-handling/src/hooks/useKeyboard.ts#L55
* Handle Interactive Behavior: https://github.com/yusufyildirim/react-native-bottom-sheet/blob/fix/keyboard-handling/src/components/bottomSheet/BottomSheet.tsx#L589
* Keyboard state change detected: https://github.com/yusufyildirim/react-native-bottom-sheet/blob/fix/keyboard-handling/src/components/bottomSheet/BottomSheet.tsx#L1438
* `animatedKeyboardHeightInContainer` recalculated: https://github.com/yusufyildirim/react-native-bottom-sheet/blob/fix/keyboard-handling/src/components/bottomSheet/BottomSheet.tsx#L309


## Why it's happening?
There's [OnKeyboardStateChange reaction](https://github.com/yusufyildirim/react-native-bottom-sheet/blob/fix/keyboard-handling/src/components/bottomSheet/BottomSheet.tsx#L1376) that reacts to keyboard height and state changes to push the bottom sheet up when necessary. It calls [getNextPosition](https://github.com/yusufyildirim/react-native-bottom-sheet/blob/fix/keyboard-handling/src/components/bottomSheet/BottomSheet.tsx#L538) function (right [here](https://github.com/yusufyildirim/react-native-bottom-sheet/blob/fix/keyboard-handling/src/components/bottomSheet/BottomSheet.tsx#L1438)) to understand where the bottom sheet should be placed so it can animate it to that position. So far so good. `getNextPosition` function [depends on](https://github.com/yusufyildirim/react-native-bottom-sheet/blob/fix/keyboard-handling/src/components/bottomSheet/BottomSheet.tsx#L590) [`animatedKeyboardHeightInContainer` value](https://github.com/yusufyildirim/react-native-bottom-sheet/blob/fix/keyboard-handling/src/components/bottomSheet/BottomSheet.tsx#L297) --used to be `getKeyboardHeightInContainer`-- make the calculation. `animatedKeyboardHeightInContainer` derives itself from `animatedKeyboardHeight` which is pretty much the keyboard height value. This is where the bug is.

If you check the screen recording above carefully, you'll see on the second line that the keyboard height value is immediately set. But yet, on the third line, `animatedKeyboardHeightInContainer` value is `0` when it's accessed within the `getNextPosition` function. I said `animatedKeyboardHeightInContainer` is derived from the keyboard height, so "how's this possible?" you might ask. The answer is on the fifth line, `animatedKeyboardHeightInContainer` value is being recalculated *after* `OnKeyboardStateChange` reaction and `getNextPosition` function are called.

It used to be not a problem because `getNextPosition` was using `getKeyboardHeightInContainer` which was a synchronous function call. `getKeyboardHeightInContainer` was accessing the latest keyboard height value which was already set at the time it's called. Since it's replaced with `animatedKeyboardHeightInContainer`, a derived state, whenever we access it, we get the latest memoized result. If it's not recalculated before we call it, we don't actually get the latest state.

To fix this problem, I added `animatedKeyboardHeightInContainer` to the `OnKeyboardStateChange` reaction as an input hoping it'll be re-triggered even if `animatedKeyboardHeightInContainer` calculation occurs later like it happens in our case. But, while I was waiting for a re-trigger, it never happened. `animatedKeyboardHeightInContainer` started to be calculated before, all the time, which is good. I believe `reanimated` running some sort of dependency analysis algorithm that started to understand it should recalculate `animatedKeyboardHeightInContainer` before calling the `OnKeyboardStateChange`.

Quite a story for a one-line change but I think it is super important to explain. I hope it helps!