### PR TITLE
feat: add scrollable scroll position callback

### DIFF
--- a/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
+++ b/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
@@ -1,6 +1,11 @@
 import React, { forwardRef, useImperativeHandle, useMemo, useRef } from 'react';
 import { Platform } from 'react-native';
-import { useAnimatedProps, useAnimatedStyle } from 'react-native-reanimated';
+import {
+  runOnJS,
+  useAnimatedProps,
+  useAnimatedReaction,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
 import { NativeViewGestureHandler } from 'react-native-gesture-handler';
 import BottomSheetDraggableView from '../bottomSheetDraggableView';
 import BottomSheetRefreshControl from '../bottomSheetRefreshControl';
@@ -35,6 +40,7 @@ export function createBottomSheetScrollableComponent<T, P>(
       style,
       refreshing,
       onRefresh,
+      onScrollPositionUpdate,
       progressViewOffset,
       refreshControl,
       ...rest
@@ -96,6 +102,13 @@ export function createBottomSheetScrollableComponent<T, P>(
       scrollableContentOffsetY,
       onRefresh !== undefined,
       focusHook
+    );
+    useAnimatedReaction(
+      () => scrollableContentOffsetY,
+      result => {
+        runOnJS(onScrollPositionUpdate)({ position: result.value });
+      },
+      [scrollableContentOffsetY.value]
     );
     //#endregion
 

--- a/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
+++ b/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
@@ -106,9 +106,11 @@ export function createBottomSheetScrollableComponent<T, P>(
     useAnimatedReaction(
       () => scrollableContentOffsetY,
       result => {
-        runOnJS(onScrollPositionUpdate)({ position: result.value });
+        if (onScrollPositionUpdate) {
+          runOnJS(onScrollPositionUpdate)({ position: result.value });
+        }
       },
-      [scrollableContentOffsetY.value]
+      [scrollableContentOffsetY.value, onScrollPositionUpdate]
     );
     //#endregion
 

--- a/src/components/bottomSheetScrollable/types.d.ts
+++ b/src/components/bottomSheetScrollable/types.d.ts
@@ -51,7 +51,7 @@ export interface BottomSheetScrollableProps {
   /**
    * Called when there is a scroll position update
    */
-  onScrollPositionUpdate: (position: number) => void;
+  onScrollPositionUpdate: ({ position }: { position: number }) => void;
 }
 
 export type ScrollableProps<T> =

--- a/src/components/bottomSheetScrollable/types.d.ts
+++ b/src/components/bottomSheetScrollable/types.d.ts
@@ -47,6 +47,11 @@ export interface BottomSheetScrollableProps {
    * @default useScrollEventsHandlersDefault
    */
   scrollEventsHandlersHook?: ScrollEventsHandlersHookType;
+
+  /**
+   * Called when there is a scroll position update
+   */
+  onScrollPositionUpdate: (position: number) => void;
 }
 
 export type ScrollableProps<T> =

--- a/src/hooks/useScrollEventsHandlersDefault.ts
+++ b/src/hooks/useScrollEventsHandlersDefault.ts
@@ -26,7 +26,8 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
   //#region callbacks
   const handleOnScroll: ScrollEventHandlerCallbackType<ScrollEventContextType> =
     useWorkletCallback(
-      (_, context) => {
+      ({ contentOffset: { y } }, context) => {
+        scrollableContentOffsetY.value = y;
         /**
          * if sheet position is extended or fill parent, then we reset
          * `shouldLockInitialPosition` value to false.


### PR DESCRIPTION
## Motivation

At the moment, it's not possible with the default config to listen to the scroll position change as the onScroll prop is not passed down to the underlying ScrollView component.
This change allows us to listen to the scroll position change and do things such as animating the header component.

On scroll position update in the default scroll events handler, update scrollableContentOffsetY.
In `createBottomSheetScrollableComponent`, perform the callback and provide the latest scrollableContentOffsetY value through the use of `useAnimatedReaction`.

Currently I use this functionality in a patch-package, and it works for us.

**Example usage:**

```
<BottomSheetScrollView
    onScrollPositionUpdate={({position}) => {
        // Do something with the position value
    }}>
    ...
</BottomSheetScrollView>
```