### PR TITLE
fix: broken link to React Navigation Example

### DIFF
--- a/docs/guides/react-naigation.md
+++ b/docs/guides/react-naigation.md
@@ -24,4 +24,4 @@ However, there are some tricks has to be follow to enable both libraries to work
 
 - You need to override `safeAreaInsets`, by default `React Navigation` add the safe area insets to all its navigators, but since your navigator will properly won't cover full screen, you will need to override it and set it to `0`.
 
-For more details regarding the implementation, please have a look at the [Navigator Example](https://github.com/gorhom/react-native-bottom-sheet/blob/master/example/src/screens/integrations/NavigatorExample.tsx).
+For more details regarding the implementation, please have a look at the [Navigator Example](https://github.com/gorhom/react-native-bottom-sheet/blob/master/example/bare/src/screens/integrations/NavigatorExample.tsx).


### PR DESCRIPTION
React Navigation Integration page has a broken link to the example code which is now under `bare` directory under `example`. 