### PR TITLE
Update react-native-redash to 17.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@gorhom/portal": "1.0.13",
     "invariant": "^2.2.4",
     "nanoid": "^3.3.3",
-    "react-native-redash": "^16.1.1"
+    "react-native-redash": "^17.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.1.0",


### PR DESCRIPTION
Updates react-native-redash to version 17.0.0 to bring in support for Reanimated 3.

## Motivation

Reanimated 3 dropped support for version 1 API's, which `react-native-redash: ^16.1.1` was still dependent on. Version 17.0.0 in `react-native-redash` removed these dependencies on Reanimated 1 API's and is compatible with Reanimated 3.
