### PR TITLE
fix: closed bottom sheet snap point

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -210,7 +210,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       animateOnMount ? -1 : _providedIndex
     );
     const animatedPosition = useSharedValue(INITIAL_POSITION);
-    const animatedNextPosition = useSharedValue(0);
+    const animatedNextPosition = useSharedValue(Number.NEGATIVE_INFINITY);
     const animatedNextPositionIndex = useSharedValue(0);
 
     // conditional


### PR DESCRIPTION
closed bottom sheet can't directly snap to 100% because initial animatedNextPosition is 0 and 100%'s nextPosition is 0 too.

## Motivation
this kind of sheets can't open
```
const snapPoint = ['100%'];
const ref = useRef<BottomSheet>(null);

const handlePress = () => {
    // doesn't work
    ref.current?.snapToIndex(0);
};

return (
  <Container>
    <Button onPress={handlePress} />
    <BottomSheet
      ref={ref}
      index={-1}
      snapPoints={snapPoint}
    />
  </Container>
)
```

in `animateToPositionCompleted`, `animatedNextPosition` always set to `Number.NEGATIVE_INFINITY` so this value can be initial value.
