### PR TITLE
fix(web): replace setNativeProps with useState

### DIFF
--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -1,4 +1,5 @@
-import React, { memo, useCallback, useMemo, useRef } from 'react';
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { ViewProps } from 'react-native';
 import Animated, {
   interpolate,
   Extrapolate,
@@ -46,8 +47,9 @@ const BottomSheetBackdropComponent = ({
   //#endregion
 
   //#region variables
-  const containerRef = useRef<Animated.View>(null);
-  const pointerEvents = enableTouchThrough ? 'none' : 'auto';
+  const [pointerEvents, setPointerEvents] = useState<
+    ViewProps['pointerEvents']
+  >(enableTouchThrough ? 'none' : 'auto');
   //#endregion
 
   //#region callbacks
@@ -62,13 +64,7 @@ const BottomSheetBackdropComponent = ({
   }, [snapToIndex, close, disappearsOnIndex, pressBehavior]);
   const handleContainerTouchability = useCallback(
     (shouldDisableTouchability: boolean) => {
-      if (!containerRef.current) {
-        return;
-      }
-      // @ts-ignore
-      containerRef.current.setNativeProps({
-        pointerEvents: shouldDisableTouchability ? 'none' : 'auto',
-      });
+      setPointerEvents(shouldDisableTouchability ? 'none' : 'auto');
     },
     []
   );
@@ -118,8 +114,8 @@ const BottomSheetBackdropComponent = ({
   return pressBehavior !== 'none' ? (
     <TapGestureHandler onGestureEvent={gestureHandler}>
       <Animated.View
-        ref={containerRef}
         style={containerStyle}
+        pointerEvents={pointerEvents}
         accessible={true}
         accessibilityRole="button"
         accessibilityLabel="Bottom Sheet backdrop"
@@ -131,11 +127,7 @@ const BottomSheetBackdropComponent = ({
       </Animated.View>
     </TapGestureHandler>
   ) : (
-    <Animated.View
-      ref={containerRef}
-      pointerEvents={pointerEvents}
-      style={containerStyle}
-    >
+    <Animated.View pointerEvents={pointerEvents} style={containerStyle}>
       {children}
     </Animated.View>
   );


### PR DESCRIPTION
## Motivation

This PR address the issue https://github.com/gorhom/react-native-bottom-sheet/issues/1068 which only occurs on web.

Backdrop is preventing any clicks trought. This happens because _pointerEvents_ are never set to actual DOM node. _pointerEvents_ are set with _setNativeProps_ however _setNativeProps_ is not really supported on _react-native-web_. In this simple case _setNativeProps_ can be replace with simple _useState_ and applying _pointerEvents_ directly on element.

It is easy to verify that this fix works. Simply open expo example and navigate to Modal Backdrop or Advance Backdrop. Buttons were not clickable before the fix.

