### PR TITLE
fix: Link to NavigationExample.tsx

### DIFF
--- a/docs/guides/react-naigation.md
+++ b/docs/guides/react-naigation.md
@@ -24,4 +24,4 @@ However, there are some tricks has to be follow to enable both libraries to work
 
 - You need to override `safeAreaInsets`, by default `React Navigation` add the safe area insets to all its navigators, but since your navigator will properly won't cover full screen, you will need to override it and set it to `0`.
 
-For more details regarding the implementation, please have a look at the [Navigator Example](https://github.com/gorhom/react-native-bottom-sheet/blob/master/example/src/screens/integrations/NavigatorExample.tsx).
+For more details regarding the implementation, please have a look at the [Navigator Example](https://github.com/gorhom/react-native-bottom-sheet/blob/master/example/bare/src/screens/integrations/NavigatorExample.tsx).


### PR DESCRIPTION
Change the URL link for the Navigator Example

The read more link for the React navigation part was broken, I think the address was changed so I changed it, taking the exact location, and replaced it with the read more link on that page

## Motivation

I was looking through the project documentation, and I saw that the part I was looking for had a link to read more, but that link wasn't working, so I went there in the project, looked for the file, in this case the address, and I made the proper replacement of the address in the link to read more the part of react Navigation.

