### PR TITLE
Fix the broken "Navigator Example" link in documentation

### DIFF
--- a/docs/guides/react-naigation.md
+++ b/docs/guides/react-naigation.md
@@ -24,4 +24,4 @@ However, there are some tricks has to be follow to enable both libraries to work
 
 - You need to override `safeAreaInsets`, by default `React Navigation` add the safe area insets to all its navigators, but since your navigator will properly won't cover full screen, you will need to override it and set it to `0`.
 
-For more details regarding the implementation, please have a look at the [Navigator Example](https://github.com/gorhom/react-native-bottom-sheet/blob/master/example/src/screens/integrations/NavigatorExample.tsx).
+For more details regarding the implementation, please have a look at the [Navigator Example](https://github.com/gorhom/react-native-bottom-sheet/blob/master/example/bare/src/screens/integrations/NavigatorExample.tsx).


### PR DESCRIPTION
Fixes the broken "Navigator Example" link.

Please provide enough information so that others can review your pull request:

## Motivation

The link to the "Navigator Example" was broken. This PR fixes the link to point to the example in the [bare](https://github.com/gorhom/react-native-bottom-sheet/tree/master/example/bare) example. I couldn't see any other examples of navigators so I assume this is the correct file.

