### PR TITLE
fix: check if next and current indices are different before animating to a snap position

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1315,7 +1315,10 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          * if snap points changed while sheet is animating, then
          * we stop the animation and animate to the updated point.
          */
-        if (animatedAnimationState.value === ANIMATION_STATE.RUNNING) {
+        if (
+          animatedAnimationState.value === ANIMATION_STATE.RUNNING &&
+          animatedNextPositionIndex.value !== animatedCurrentIndex.value
+        ) {
           nextPosition =
             animatedNextPositionIndex.value !== -1
               ? snapPoints[animatedNextPositionIndex.value]


### PR DESCRIPTION
Fixes #1094 

## Motivation

On Android the bottomsheet was getting stuck to the height of keyboard when a user would open and close the keyboard really quickly. It was because of the following lines: https://github.com/gorhom/react-native-bottom-sheet/blob/cebae97c56f0b2ff31c247b1fce5cbe8172b6554/src/components/bottomSheet/BottomSheet.tsx#L1318-L1323

while doing the check if animation state is running and snapping to that point, it also has to make sure current and next indices are not equal since in that case the user did not try to snap to any point.

Using the following example:
```
import { GestureHandlerRootView } from "react-native-gesture-handler";
// Utility Imports
import BottomSheet from "./src";
import { Button, Keyboard, StyleSheet, Text, TextInput } from "react-native";
import { useRef } from "react";

const snapPoints = ["20%", "90%"];

export default function App() {
  const bottomsheetRef = useRef<BottomSheet>(null);

  return (
    <GestureHandlerRootView style={styles.container}>
      <Button title="close keyboard" onPress={() => Keyboard.dismiss()} />
      <Button
        title="first snapPoint"
        onPress={() => bottomsheetRef.current?.snapToIndex(0)}
      />
      <Button
        title="second snapPoint"
        onPress={() => bottomsheetRef.current?.snapToIndex(1)}
      />
      <TextInput style={styles.input} placeholder={"message"} />
      <BottomSheet
        ref={bottomsheetRef}
        snapPoints={snapPoints}
        index={-1}
        enablePanDownToClose
        backgroundStyle={{ backgroundColor: "#ccc" }}
      >
        <Text>Hello there</Text>
      </BottomSheet>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: "space-around",
    backgroundColor: "white",
  },
  input: {
    backgroundColor: "#eee",
    padding: 8,
  },
});

```

Before: 

https://user-images.githubusercontent.com/80689446/189399126-765ad3a6-7b3e-43e1-a8a8-98e3bd2d384f.mp4

After: 

https://user-images.githubusercontent.com/80689446/189399141-8a1baddf-6e4a-4ef6-a6ac-1954d65a4f58.mp4




