### PR TITLE
refactor: replace findNodeHandle for getRefNativeTag

### DIFF
--- a/src/hooks/useScrollable.ts
+++ b/src/hooks/useScrollable.ts
@@ -1,6 +1,6 @@
 import { useCallback, RefObject, useRef } from 'react';
-import { findNodeHandle } from 'react-native';
 import { useSharedValue } from 'react-native-reanimated';
+import { getRefNativeTag } from '../utilities/getRefNativeTag';
 import { SCROLLABLE_STATE, SCROLLABLE_TYPE } from '../constants';
 import type { ScrollableRef, Scrollable } from '../types';
 
@@ -38,7 +38,7 @@ export const useScrollable = () => {
     // find node handle id
     let id;
     try {
-      id = findNodeHandle(ref.current);
+      id = getRefNativeTag(ref);
     } catch {
       return;
     }

--- a/src/hooks/useScrollableSetter.ts
+++ b/src/hooks/useScrollableSetter.ts
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect } from 'react';
-import { findNodeHandle } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { useBottomSheetInternal } from './useBottomSheetInternal';
+import { getRefNativeTag } from '../utilities/getRefNativeTag';
 import { SCROLLABLE_TYPE } from '../constants';
 import type { Scrollable } from '../types';
 
@@ -31,7 +31,7 @@ export const useScrollableSetter = (
     isContentHeightFixed.value = false;
 
     // set current scrollable ref
-    const id = findNodeHandle(ref.current);
+    const id = getRefNativeTag(ref);
     if (id) {
       setScrollableRef({
         id: id,

--- a/src/utilities/getRefNativeTag.ts
+++ b/src/utilities/getRefNativeTag.ts
@@ -1,0 +1,43 @@
+const isFunction = (ref: unknown): ref is Function => typeof ref === 'function';
+
+const hasNativeTag = (
+  ref: unknown
+): ref is { current: { _nativeTag: number } } =>
+  !!ref &&
+  typeof ref === 'object' &&
+  'current' in (ref || {}) &&
+  '_nativeTag' in ((ref as any)?.current || {});
+
+/*
+ * getRefNativeTag is an internal utility used by createBottomSheetScrollableComponent
+ * to grab the native tag from the native host component. It only works when the ref
+ * is pointing to a native Host component.
+ *
+ * Internally in the bottom-sheet library ref can be a function that returns a native tag
+ * this seems to happen due to the usage of Reanimated's animated scroll components.
+ *
+ * This should be Fabric compatible as long as the ref is a native host component.
+ * */
+export function getRefNativeTag(ref: unknown) {
+  const refType = typeof ref;
+  let nativeTag: undefined | number;
+  if (isFunction(ref)) {
+    nativeTag = ref();
+  } else if (hasNativeTag(ref)) {
+    nativeTag = ref.current._nativeTag;
+  }
+
+  if (!nativeTag || typeof nativeTag !== 'number') {
+    throw new Error(
+      `Unexpected nativeTag: ${refType}; nativeTag=${nativeTag} 
+
+			createBottomSheetScrollableComponent's ScrollableComponent needs to return 
+			a reference that contains a nativeTag to a Native HostComponent.
+
+			ref=${ref}
+			`
+    );
+  }
+
+  return nativeTag;
+}


### PR DESCRIPTION
## Motivation

Make this library compliant with the new Fabric architecture. [Follow up to the Fabric enabled example app](https://github.com/gorhom/react-native-bottom-sheet/pull/1099).



Gif of it working with old architecture:

![bottom-sheet-scrollable-demo](https://user-images.githubusercontent.com/20777666/189998895-48301f23-cf17-497f-9e9b-a26e83926e54.gif)

Gif of it working with Fabric: (note example app is slightly broken due to dependencies not being fully compatible yet)

![android_ios_demo_bottom_sheet](https://user-images.githubusercontent.com/20777666/189999763-9f9e9dbd-11aa-4ae4-9eca-6b4aad9439c4.gif)


cc @gorhom 
