### PR TITLE
fix: prevent not defined error on web

### DIFF
--- a/src/utilities/logger.ts
+++ b/src/utilities/logger.ts
@@ -8,8 +8,11 @@ type Print = (options: PrintOptions) => void;
 
 let isLoggingEnabled = false;
 
+// __DEV__ global is by default not defined in React Native Web builds
+const isDev = Boolean(typeof __DEV__ !== 'undefined' && __DEV__)
+
 const enableLogging = () => {
-  if (!__DEV__) {
+  if (!isDev) {
     console.warn('[BottomSheet] could not enable logging on production!');
     return;
   }
@@ -18,7 +21,7 @@ const enableLogging = () => {
 
 let print: Print = () => {};
 
-if (__DEV__) {
+if (isDev) {
   print = ({ component, method, params }) => {
     if (!isLoggingEnabled) {
       return;


### PR DESCRIPTION
Checking the `__DEV__` global variable in logger.ts will cause an error in React Native Web. Similar to the issue raised in [@gorhom/react-native-portal](https://github.com/gorhom/react-native-portal/issues/29). This is just a copy of AlanSl's [solution](https://github.com/gorhom/react-native-portal/pull/30) for this problem at @gorhom/react-native-portal.
