### PR TITLE
fix : replace Extrapolate with Animated.Extrapolate

### DIFF
--- a/example/app/src/components/customFooter/CustomFooter.tsx
+++ b/example/app/src/components/customFooter/CustomFooter.tsx
@@ -8,7 +8,6 @@ import {
 import { RectButton } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, {
-  Extrapolate,
   interpolate,
   useAnimatedStyle,
 } from 'react-native-reanimated';
@@ -32,7 +31,7 @@ const CustomFooterComponent = ({
       animatedIndex.value,
       [0, 1],
       [toRad(0), toRad(-180)],
-      Extrapolate.CLAMP
+      Animated.Extrapolate.CLAMP
     );
     return {
       transform: [{ rotate: `${arrowRotate}rad` }],
@@ -48,7 +47,7 @@ const CustomFooterComponent = ({
         animatedIndex.value,
         [-0.85, 0],
         [0, 1],
-        Extrapolate.CLAMP
+        Animated.Extrapolate.CLAMP
       ),
     }),
     [animatedIndex]

--- a/example/app/src/components/customHandle/CustomHandle.tsx
+++ b/example/app/src/components/customHandle/CustomHandle.tsx
@@ -2,7 +2,6 @@ import React, { memo, useMemo } from 'react';
 import { StyleProp, StyleSheet, Text, ViewStyle } from 'react-native';
 import { BottomSheetHandleProps } from '@gorhom/bottom-sheet';
 import Animated, {
-  Extrapolate,
   interpolate,
   useAnimatedStyle,
   useDerivedValue,
@@ -23,7 +22,7 @@ const CustomHandleComponent: React.FC<CustomHandleProps> = ({
   //#region animations
 
   const indicatorTransformOriginY = useDerivedValue(() =>
-    interpolate(animatedIndex.value, [0, 1, 2], [-1, 0, 1], Extrapolate.CLAMP)
+    interpolate(animatedIndex.value, [0, 1, 2], [-1, 0, 1], Animated.Extrapolate.CLAMP)
   );
   //#endregion
 
@@ -34,7 +33,7 @@ const CustomHandleComponent: React.FC<CustomHandleProps> = ({
       animatedIndex.value,
       [1, 2],
       [20, 0],
-      Extrapolate.CLAMP
+      Animated.Extrapolate.CLAMP
     );
     return {
       borderTopLeftRadius: borderTopRadius,
@@ -53,7 +52,7 @@ const CustomHandleComponent: React.FC<CustomHandleProps> = ({
       animatedIndex.value,
       [0, 1, 2],
       [toRad(-30), 0, toRad(30)],
-      Extrapolate.CLAMP
+      Animated.Extrapolate.CLAMP
     );
     return {
       transform: transformOrigin(
@@ -79,7 +78,7 @@ const CustomHandleComponent: React.FC<CustomHandleProps> = ({
       animatedIndex.value,
       [0, 1, 2],
       [toRad(30), 0, toRad(-30)],
-      Extrapolate.CLAMP
+      Animated.Extrapolate.CLAMP
     );
     return {
       transform: transformOrigin(

--- a/example/bare/src/components/weather/Weather.tsx
+++ b/example/bare/src/components/weather/Weather.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import { Dimensions, StyleSheet } from 'react-native';
 import Animated, {
-  Extrapolate,
   interpolate,
   useAnimatedStyle,
 } from 'react-native-reanimated';
@@ -45,7 +44,7 @@ const Weather = ({ animatedIndex, animatedPosition }: WeatherProps) => {
             animatedIndex.value,
             [1, 1.25],
             [1, 0],
-            Extrapolate.CLAMP
+            Animated.Extrapolate.CLAMP
           ),
         },
       ],

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -15,7 +15,6 @@ import Animated, {
   useDerivedValue,
   runOnJS,
   interpolate,
-  Extrapolate,
   runOnUI,
   cancelAnimation,
   useWorkletCallback,
@@ -471,7 +470,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
             animatedPosition.value,
             adjustedSnapPoints,
             adjustedSnapPointsIndexes,
-            Extrapolate.CLAMP
+            Animated.Extrapolate.CLAMP
           )
         : -1;
 

--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback, useMemo, useState } from 'react';
 import { ViewProps } from 'react-native';
 import Animated, {
   interpolate,
-  Extrapolate,
+  ,
   useAnimatedStyle,
   useAnimatedReaction,
   useAnimatedGestureHandler,
@@ -91,7 +91,7 @@ const BottomSheetBackdropComponent = ({
       animatedIndex.value,
       [-1, disappearsOnIndex, appearsOnIndex],
       [0, 0, opacity],
-      Extrapolate.CLAMP
+      Animated.Extrapolate.CLAMP
     ),
     flex: 1,
   }));


### PR DESCRIPTION
there is a problem in react-native-reanimated which is "Extrapolate" has not been exported properly.
if you try to log the Extrapolate this way it will print undefined.
the quick workaround is to use "Animated.Extrapolate" which I did in this pull request.