### PR TITLE
fix: setting state only if ref is set on Animated.View in BottomSheetBackdropComponent

### DIFF
--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo, useState } from 'react';
+import React, { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { ViewProps } from 'react-native';
 import Animated, {
   interpolate,
@@ -48,6 +48,7 @@ const BottomSheetBackdropComponent = ({
   //#endregion
 
   //#region variables
+  const containerRef = useRef<Animated.View>(null);
   const [pointerEvents, setPointerEvents] = useState<
     ViewProps['pointerEvents']
   >(enableTouchThrough ? 'none' : 'auto');
@@ -67,6 +68,9 @@ const BottomSheetBackdropComponent = ({
   }, [snapToIndex, close, disappearsOnIndex, pressBehavior, onPress]);
   const handleContainerTouchability = useCallback(
     (shouldDisableTouchability: boolean) => {
+      if (!containerRef.current) {
+        return;
+      }
       setPointerEvents(shouldDisableTouchability ? 'none' : 'auto');
     },
     []
@@ -117,6 +121,7 @@ const BottomSheetBackdropComponent = ({
   return pressBehavior !== 'none' ? (
     <TapGestureHandler onGestureEvent={gestureHandler}>
       <Animated.View
+        ref={containerRef}
         style={containerStyle}
         pointerEvents={pointerEvents}
         accessible={true}
@@ -130,7 +135,11 @@ const BottomSheetBackdropComponent = ({
       </Animated.View>
     </TapGestureHandler>
   ) : (
-    <Animated.View pointerEvents={pointerEvents} style={containerStyle}>
+    <Animated.View
+      ref={containerRef}
+      pointerEvents={pointerEvents}
+      style={containerStyle}
+    >
       {children}
     </Animated.View>
   );


### PR DESCRIPTION
## Motivation

After upgrading to version 4.4.5 from version 4.4.3 we noticed this react warning coming in: 
```
 ERROR  Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
    in BottomSheetBackdrop
```
I seems like this was introduced in version 4.4.4 as part of [this PR](https://github.com/gorhom/react-native-bottom-sheet/pull/1076). The intention of that pr is preserved here, however we are making sure to not set state too early

