### PR TITLE
feat: added E2E props, fixed Appium issue with BottomSheetContainer

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -156,6 +156,10 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       backgroundComponent,
       footerComponent,
       children: Content,
+
+      // E2E
+      testID,
+      accessibilityLabel,
     } = props;
     //#endregion
 
@@ -1596,6 +1600,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
               bottomInset={bottomInset}
               detached={detached}
               style={_providedContainerStyle}
+              testID={testID}
+              accessibilityLabel={accessibilityLabel}
             >
               <Animated.View style={containerStyle}>
                 <BottomSheetBackgroundContainer

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import type { ViewStyle, Insets, StyleProp } from 'react-native';
+import type { ViewStyle, Insets, StyleProp, ViewProps } from 'react-native';
 import type {
   SharedValue,
   AnimateStyle,
@@ -19,8 +19,11 @@ import type {
 } from '../../constants';
 import type { GestureEventsHandlersHookType } from '../../types';
 
+type ViewTestIDProps = Pick<ViewProps, 'testID' | 'accessibilityLabel'>;
+
 export interface BottomSheetProps
   extends BottomSheetAnimationConfigs,
+    ViewTestIDProps,
     Partial<
       Pick<
         PanGestureHandlerProps,

--- a/src/components/bottomSheetContainer/BottomSheetContainer.tsx
+++ b/src/components/bottomSheetContainer/BottomSheetContainer.tsx
@@ -20,6 +20,8 @@ function BottomSheetContainerComponent({
   detached,
   style,
   children,
+  testID,
+  accessibilityLabel,
 }: BottomSheetContainerProps) {
   const containerRef = useRef<View>(null);
   //#region styles
@@ -80,6 +82,9 @@ function BottomSheetContainerComponent({
       onLayout={shouldCalculateHeight ? handleContainerLayout : undefined}
       style={containerStyle}
       children={children}
+      accessible={false}
+      testID={testID}
+      accessibilityLabel={accessibilityLabel}
     />
   );
   //#endregion

--- a/src/components/bottomSheetContainer/types.d.ts
+++ b/src/components/bottomSheetContainer/types.d.ts
@@ -3,10 +3,14 @@ import type { Insets, StyleProp, ViewStyle } from 'react-native';
 import type Animated from 'react-native-reanimated';
 import type { BottomSheetProps } from '../bottomSheet/types';
 
-export interface BottomSheetContainerProps
-  extends Partial<
-    Pick<BottomSheetProps, 'topInset' | 'bottomInset' | 'detached'>
-  > {
+type PartialBottomSheetProps = Partial<
+  Pick<
+    BottomSheetProps,
+    'topInset' | 'bottomInset' | 'detached' | 'testID' | 'accessibilityLabel'
+  >
+>;
+
+export interface BottomSheetContainerProps extends PartialBottomSheetProps {
   containerHeight: Animated.SharedValue<number>;
   containerOffset: Animated.SharedValue<Insets>;
   shouldCalculateHeight?: boolean;


### PR DESCRIPTION
## Motivation
This PR introduces improvements that are vital for creating E2E tests with Appium and BottomSheet, closes #1141 

1. Current version missing `testID` and `accessibilityLabel` props in root BottomSheetContainer , currently the only workaround is to create additional inner wrapper view and pass `testID` and `accessibilityLabel`. 
2. Due to missing `accessible={false}` prop in the `BottomSheetContainer` appium does not see the content of the BottomSheet and you cannot create E2E tests interacting with it.

