### PR TITLE
feat: upgrade for reanimated 2.3x

### DIFF
--- a/example/app/src/components/customFooter/CustomFooter.tsx
+++ b/example/app/src/components/customFooter/CustomFooter.tsx
@@ -8,7 +8,7 @@ import {
 import { RectButton } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, {
-  Extrapolate,
+  Extrapolation,
   interpolate,
   useAnimatedStyle,
 } from 'react-native-reanimated';
@@ -32,7 +32,7 @@ const CustomFooterComponent = ({
       animatedIndex.value,
       [0, 1],
       [toRad(0), toRad(-180)],
-      Extrapolate.CLAMP
+      Extrapolation.CLAMP
     );
     return {
       transform: [{ rotate: `${arrowRotate}rad` }],
@@ -48,7 +48,7 @@ const CustomFooterComponent = ({
         animatedIndex.value,
         [-0.85, 0],
         [0, 1],
-        Extrapolate.CLAMP
+        Extrapolation.CLAMP
       ),
     }),
     [animatedIndex]

--- a/example/app/src/components/customHandle/CustomHandle.tsx
+++ b/example/app/src/components/customHandle/CustomHandle.tsx
@@ -2,7 +2,7 @@ import React, { memo, useMemo } from 'react';
 import { StyleProp, StyleSheet, Text, ViewStyle } from 'react-native';
 import { BottomSheetHandleProps } from '@gorhom/bottom-sheet';
 import Animated, {
-  Extrapolate,
+  Extrapolation,
   interpolate,
   useAnimatedStyle,
   useDerivedValue,
@@ -23,7 +23,7 @@ const CustomHandleComponent: React.FC<CustomHandleProps> = ({
   //#region animations
 
   const indicatorTransformOriginY = useDerivedValue(() =>
-    interpolate(animatedIndex.value, [0, 1, 2], [-1, 0, 1], Extrapolate.CLAMP)
+    interpolate(animatedIndex.value, [0, 1, 2], [-1, 0, 1], Extrapolation.CLAMP)
   );
   //#endregion
 
@@ -34,7 +34,7 @@ const CustomHandleComponent: React.FC<CustomHandleProps> = ({
       animatedIndex.value,
       [1, 2],
       [20, 0],
-      Extrapolate.CLAMP
+      Extrapolation.CLAMP
     );
     return {
       borderTopLeftRadius: borderTopRadius,
@@ -53,7 +53,7 @@ const CustomHandleComponent: React.FC<CustomHandleProps> = ({
       animatedIndex.value,
       [0, 1, 2],
       [toRad(-30), 0, toRad(30)],
-      Extrapolate.CLAMP
+      Extrapolation.CLAMP
     );
     return {
       transform: transformOrigin(
@@ -79,7 +79,7 @@ const CustomHandleComponent: React.FC<CustomHandleProps> = ({
       animatedIndex.value,
       [0, 1, 2],
       [toRad(30), 0, toRad(-30)],
-      Extrapolate.CLAMP
+      Extrapolation.CLAMP
     );
     return {
       transform: transformOrigin(

--- a/example/bare/src/components/weather/Weather.tsx
+++ b/example/bare/src/components/weather/Weather.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { Dimensions, StyleSheet } from 'react-native';
 import Animated, {
-  Extrapolate,
+  Extrapolation,
   interpolate,
   useAnimatedStyle,
 } from 'react-native-reanimated';
@@ -45,7 +45,7 @@ const Weather = ({ animatedIndex, animatedPosition }: WeatherProps) => {
             animatedIndex.value,
             [1, 1.25],
             [1, 0],
-            Extrapolate.CLAMP
+            Extrapolation.CLAMP
           ),
         },
       ],

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -15,7 +15,7 @@ import Animated, {
   useDerivedValue,
   runOnJS,
   interpolate,
-  Extrapolate,
+  Extrapolation,
   runOnUI,
   cancelAnimation,
   useWorkletCallback,
@@ -471,7 +471,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
             animatedPosition.value,
             adjustedSnapPoints,
             adjustedSnapPointsIndexes,
-            Extrapolate.CLAMP
+            Extrapolation.CLAMP
           )
         : -1;
 

--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -2,7 +2,7 @@ import React, { memo, useCallback, useMemo, useState } from 'react';
 import { ViewProps } from 'react-native';
 import Animated, {
   interpolate,
-  Extrapolate,
+  Extrapolation,
   useAnimatedStyle,
   useAnimatedReaction,
   useAnimatedGestureHandler,
@@ -91,7 +91,7 @@ const BottomSheetBackdropComponent = ({
       animatedIndex.value,
       [-1, disappearsOnIndex, appearsOnIndex],
       [0, 0, opacity],
-      Extrapolate.CLAMP
+      Extrapolation.CLAMP
     ),
     flex: 1,
   }));


### PR DESCRIPTION

## Motivation
In reanimated 2.3x, the Extrapolate is not exported. Instead we need to use [Extrapolation](https://docs.swmansion.com/react-native-reanimated/docs/api/miscellaneous/interpolate/#extrapolation-type-object--string). This PR just find and replaces `Extrapolate` to `Extrapolation` 😄 

