### PR TITLE
Fix android issues with dynamic snap points and open keyboard + `onAnimate` values

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -693,7 +693,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         /**
          * store next position
          */
-        animatedNextPosition.value = position;
+        animatedNextPosition.value = position + animatedKeyboardHeight.value;
         animatedNextPositionIndex.value =
           animatedSnapPoints.value.indexOf(position + animatedKeyboardHeight.value);
 

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -602,8 +602,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     );
     const handleOnAnimate = useCallback(
       function handleOnAnimate(toPoint: number) {
+        const keyboardOffset = animatedKeyboardState.value == KEYBOARD_STATE.SHOWN ? animatedKeyboardHeight.value : 0;
         const snapPoints = animatedSnapPoints.value;
-        const toIndex = snapPoints.indexOf(toPoint);
+        const toIndex = toPoint == 0 ? INITIAL_SNAP_POINT : snapPoints.indexOf(toPoint + keyboardOffset);
 
         print({
           component: BottomSheet.name,
@@ -696,13 +697,12 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         const keyboardOffset = animatedKeyboardState.value == KEYBOARD_STATE.SHOWN ? animatedKeyboardHeight.value : 0;
 
         animatedNextPosition.value = position + keyboardOffset;
-        animatedNextPositionIndex.value =
-          animatedSnapPoints.value.indexOf(position + keyboardOffset);
+        animatedNextPositionIndex.value = position == 0 ? INITIAL_SNAP_POINT : animatedSnapPoints.value.indexOf(position + keyboardOffset);
 
         /**
          * fire `onAnimate` callback
          */
-        runOnJS(handleOnAnimate)(position + keyboardOffset);
+        runOnJS(handleOnAnimate)(position);
 
         /**
          * force animation configs from parameters, if provided

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -603,7 +603,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     const handleOnAnimate = useCallback(
       function handleOnAnimate(toPoint: number) {
         const snapPoints = animatedSnapPoints.value;
-        const toIndex = snapPoints.indexOf(toPoint);
+        const toIndex = snapPoints.indexOf(toPoint + animatedKeyboardHeight.value);
 
         print({
           component: BottomSheet.name,

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -603,7 +603,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     const handleOnAnimate = useCallback(
       function handleOnAnimate(toPoint: number) {
         const snapPoints = animatedSnapPoints.value;
-        const toIndex = snapPoints.indexOf(toPoint + animatedKeyboardHeight.value);
+        const toIndex = snapPoints.indexOf(toPoint);
 
         print({
           component: BottomSheet.name,
@@ -693,14 +693,16 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         /**
          * store next position
          */
-        animatedNextPosition.value = position + animatedKeyboardHeight.value;
+        const keyboardOffset = animatedKeyboardState.value == KEYBOARD_STATE.SHOWN ? animatedKeyboardHeight.value : 0;
+
+        animatedNextPosition.value = position + keyboardOffset;
         animatedNextPositionIndex.value =
-          animatedSnapPoints.value.indexOf(position + animatedKeyboardHeight.value);
+          animatedSnapPoints.value.indexOf(position + keyboardOffset);
 
         /**
          * fire `onAnimate` callback
          */
-        runOnJS(handleOnAnimate)(position);
+        runOnJS(handleOnAnimate)(position + keyboardOffset);
 
         /**
          * force animation configs from parameters, if provided

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -695,7 +695,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          */
         animatedNextPosition.value = position;
         animatedNextPositionIndex.value =
-          animatedSnapPoints.value.indexOf(position);
+          animatedSnapPoints.value.indexOf(position + animatedKeyboardHeight.value);
 
         /**
          * fire `onAnimate` callback


### PR DESCRIPTION
## Motivation
I was facing an issue on android when using dynamic snap points and the `adjustPan` setting **when content height changed while the keyboard was open**. I think the following video best showcases the problem:

https://user-images.githubusercontent.com/1866649/199200414-1d78a25c-538d-4021-9f27-4c4c9003d52b.mp4

as you can see, the height of the content changes when the validation text appears or disappears, thereby adding or removing about twenty pixels.

I've narrowed down the issue: because of the keyboard height, the appropriate `snapPoint` index is not found and triggers the intermediary collapse of the sheet.

I've tested this on android and ios:
- with and without dynamic snap points setting
- with single and multiple snap points
- with modal/regular bottom sheet
- with bottomsheet scrollview

I have not found this to cause any regressions, but there may be a better solution to this problem.

Edit: 
Upon further investigation, I also found some issues with `onAnimate` being provided with the wrong values (both ios and android), I've fixed that in https://github.com/gorhom/react-native-bottom-sheet/pull/1163/commits/0c7e1532eaac8cd56488ca4c9221c1afdd2714fc, but I'm starting to think my fixes are not tackling the root issue, @gorhom please advise 🙂 