### PR TITLE
Fix issue with simultaneous keyboard dismiss and sheet close

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1401,7 +1401,11 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
            */
           (Platform.OS === 'android' &&
             keyboardBehavior === KEYBOARD_BEHAVIOR.interactive &&
-            android_keyboardInputMode === KEYBOARD_INPUT_MODE.adjustResize)
+            android_keyboardInputMode === KEYBOARD_INPUT_MODE.adjustResize) ||
+          /**
+           * if the sheet is closing, then exit then method
+           */ 
+          animatedNextPositionIndex.value == -1
         ) {
           animatedKeyboardHeightInContainer.value = 0;
           return;


### PR DESCRIPTION
## Motivation
This aims to address https://github.com/gorhom/react-native-bottom-sheet/issues/1159 and https://github.com/gorhom/react-native-bottom-sheet/issues/1072

This simply exits the `OnKeyboardStateChange` callback if the sheet is about close.

This may conflict with https://github.com/gorhom/react-native-bottom-sheet/commit/a1ec74dbbc85476bb39f3637e9a97214e0cad9a0 but as I am unsure of the calendar for the `v5` release, I thought I'd open a PR for this fix only. Please advise
