### PR TITLE
Fix Memory leak in BottomSheetBackdrop

### DIFF
--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -105,7 +105,7 @@ const BottomSheetBackdropComponent = ({
   useAnimatedReaction(
     () => animatedIndex.value <= disappearsOnIndex,
     (shouldDisableTouchability, previous) => {
-      if (shouldDisableTouchability === previous) {
+      if (shouldDisableTouchability === previous || disappearsOnIndex === -1) {
         return;
       }
       runOnJS(handleContainerTouchability)(shouldDisableTouchability);


### PR DESCRIPTION
## Motivation
- Fix Memory leak in BottomSheetBackdrop that occurs when the backdrop tries to set the `pointerEvents` to `none` when dismissing the modal. If the `disappearsOnIndex` is set to `-1` and the `animatedIndex` is `<= -1` , there is no need to call `setEventPointers` since the modal should be removed.

