### PR TITLE
fix: added missing onClose mock

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -28,7 +28,9 @@ class BottomSheetModal extends React.Component {
   snapToPosition() {}
   expand() {}
   collapse() {}
-  close() {}
+  close() {
+    this.props.onClose?.();
+  }
   forceClose() {}
   present() {}
   dismiss() {}
@@ -43,7 +45,9 @@ class BottomSheet extends React.Component {
   snapToPosition() {}
   expand() {}
   collapse() {}
-  close() {}
+  close() {
+    this.props.onClose?.();
+  }
   forceClose() {}
 
   render() {


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

When testing `onClose` prop wasn't called

