### PR TITLE
fix: ensure keyboard events are not handled when TextInput is unmounted

### DIFF
--- a/src/components/bottomSheetTextInput/BottomSheetTextInput.tsx
+++ b/src/components/bottomSheetTextInput/BottomSheetTextInput.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, forwardRef } from 'react';
+import React, { memo, useCallback, forwardRef, useEffect } from 'react';
 import { TextInput } from 'react-native-gesture-handler';
 import { useBottomSheetInternal } from '../../hooks';
 import type { BottomSheetTextInputProps } from './types';
@@ -9,6 +9,12 @@ const BottomSheetTextInputComponent = forwardRef<
 >(({ onFocus, onBlur, ...rest }, ref) => {
   //#region hooks
   const { shouldHandleKeyboardEvents } = useBottomSheetInternal();
+
+  useEffect(() => {
+    return () => {
+      shouldHandleKeyboardEvents.value = false;
+    };
+  }, [shouldHandleKeyboardEvents]);
   //#endregion
 
   //#region callbacks


### PR DESCRIPTION
## Motivation

This PR fixes an issue where a bottom sheet would reopen any time a text input on the screen is focused. This would occur if the bottom sheet was dismissed and the children were hidden while a BottomSheetTextInput was focused. This change ensures that the shouldHandleKeyboardEvents is set to false if the children are unmounted. May be the problem behind #1233  