### PR TITLE
fix re-render modal when (set the parent state & close modal) at the same time 

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1561,7 +1561,6 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       _providedIndex,
       animatedCurrentIndex,
       isAnimatedOnMount,
-      handleSnapToIndex,
     ]);
     //#endregion
 


### PR DESCRIPTION
The modal re-render when set parent state and close the modal sheet at the same time using animationConfigs, also sometimes it happens without animationConfigs

**Code example :** 
 
```
function TestComponent() {
  const [value, setValue] = useState(0);
  const modalRef = useRef<BottomSheetModal>(null);

  const onOpenModal = () => {
    forwardRef.current?.present();
  };

  const onCloseAndSetState = () => {
    setValue(Math.random());
    forwardRef.current?.close();
  };

  return (
    <View style={styles.container}>
      <Button text="Open Modal" onPress={onOpenModal} />

      <BottomSheetModal
        animationConfigs={{
          duration: 300,
          easing: Easing.elastic(),
        }}
        backdropComponent={(props) => <BottomSheetBackdrop {...props} disappearsOnIndex={-1} />}
        ref={modalRef}
        snapPoints={['50%']}
      >
        <View style={styles.content}>
          <Button
            type="standard"
            text="Close Modal and Set State"
            style={styles.btn}
            onPress={onCloseAndSetState}
          />
        </View>
      </BottomSheetModal>

    </View>
  );
}
```



**This video for the issue :** 

https://user-images.githubusercontent.com/46144527/210860358-40670ffd-fd5a-4301-909f-c2f5f4d61fe6.mov


**This video with my solution in the same code**

https://user-images.githubusercontent.com/46144527/210860721-47b5a728-bf4f-4ba9-96a6-d8fb0930b0a2.mov

