### PR TITLE
bottomsheetbackdrop default value for pressBehavior

### DIFF
--- a/docs/components/bottomsheetbackdrop.md
+++ b/docs/components/bottomsheetbackdrop.md
@@ -71,7 +71,7 @@ What should happen when user press backdrop?
 
 | type                              | default | required |
 | --------------------------------- | ------- | -------- |
-| `BackdropPressBehavior` \| number | 'close' | NO       |
+| `BackdropPressBehavior` \| number | 'none' | NO       |
 
 ## Example
 


### PR DESCRIPTION
The default value for the `pressBehavior` seems to be 'none'. I had to actually add `pressBehavior={"close"}` for the close behavior to work.

This seems to be at least the case for version **_4.4.5_**.

