### PR TITLE
Feature: onRequestClose

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -266,6 +266,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     });
     const isInTemporaryPosition = useSharedValue(false);
     const isForcedClosing = useSharedValue(false);
+    const shouldPreventOnRequestClose = useSharedValue(false);
 
     // gesture
     const animatedContentGestureState = useSharedValue<State>(
@@ -957,6 +958,11 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          */
         isForcedClosing.value = true;
 
+        /**
+         * set should prevent on request close variable.
+         */
+        shouldPreventOnRequestClose.value = true;
+
         runOnUI(animateToPosition)(
           nextPosition,
           ANIMATION_SOURCE.USER,
@@ -1503,6 +1509,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       () => ({
         _animatedIndex: animatedIndex.value,
         _animatedPosition: animatedPosition.value,
+        _shouldPreventOnRequestClose: shouldPreventOnRequestClose.value,
         _animationState: animatedAnimationState.value,
         _contentGestureState: animatedContentGestureState.value,
         _handleGestureState: animatedHandleGestureState.value,
@@ -1510,6 +1517,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       ({
         _animatedIndex,
         _animationState,
+        _shouldPreventOnRequestClose,
         _contentGestureState,
         _handleGestureState,
       }) => {
@@ -1566,8 +1574,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         /**
          * if index is `-1` than we fire the `onClose` callback.
          */
-        if (_animatedIndex === -1) {
-          if(shouldCloseWithoutCallbacks.value === false) {
+        if (_animatedIndex === -1 && _animatedIndex !== prevIndex) {
+          if(!_shouldPreventOnRequestClose && shouldCloseWithoutCallbacks.value === false) {
             runOnJS(handleOnClose)(prevIndex);
             runOnJS(print)({
               component: BottomSheet.name,

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -143,6 +143,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
 
       // callbacks
       onChange: _providedOnChange,
+      onRequestClose: _providedOnRequestClose,
       onClose: _providedOnClose,
       onAnimate: _providedOnAnimate,
 
@@ -848,7 +849,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       ]
     );
     const handleClose = useCallback(
-      function handleClose(
+      async function handleClose(
         animationConfigs?: WithSpringConfig | WithTimingConfig
       ) {
         print({
@@ -869,6 +870,13 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           nextPosition === animatedNextPosition.value ||
           isForcedClosing.value
         ) {
+          return;
+        }
+
+        /**
+         * If an onRequestClose handler is provided, we await the return value to determine whether to proceed with closing.
+         */
+        if(_providedOnRequestClose && !(await _providedOnRequestClose())) {
           return;
         }
 

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -242,6 +242,12 @@ export interface BottomSheetProps
    */
   onChange?: (index: number) => void;
   /**
+   * Callback injected before the sheet is about to close. Return value of the promise determines whether to continue closing.
+   *
+   * @type () => Promise<boolean>;
+   */
+  onRequestClose?: () => Promise<boolean>;
+  /**
    * Callback when the sheet close.
    *
    * @type () => void;

--- a/src/contexts/internal.ts
+++ b/src/contexts/internal.ts
@@ -65,6 +65,7 @@ export interface BottomSheetInternalContextType
   shouldHandleKeyboardEvents: Animated.SharedValue<boolean>;
 
   // methods
+  onRequestClose?: () => Promise<boolean>;
   stopAnimation: () => void;
   animateToPosition: AnimateToPositionType;
   setScrollableRef: (ref: ScrollableRef) => void;

--- a/src/contexts/internal.ts
+++ b/src/contexts/internal.ts
@@ -65,7 +65,6 @@ export interface BottomSheetInternalContextType
   shouldHandleKeyboardEvents: Animated.SharedValue<boolean>;
 
   // methods
-  onRequestClose?: () => Promise<boolean>;
   stopAnimation: () => void;
   animateToPosition: AnimateToPositionType;
   setScrollableRef: (ref: ScrollableRef) => void;


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## About
An onRequestClose prop on the BottomSheet. This prop should accept a function returning a Promise, which should be run between user dismissal/closing interaction and the sheet actually closing (to index -1). The return value of the promise should in turn decide whether to proceed with closing the sheet.

## Motivation
In certain situations, it would be very useful to be able to interrupt any dismissal/closing of the sheet, eg. if there is unsaved changes in a form, or if some process is running. This would eg. allow you to prompt the user with an alert to confirm ending whatever workflow they are currently in.

Attempts to solve feature request #1318 

