### PR TITLE
fix(BottomSheetScrollView): Scroll responder types use mixin

### DIFF
--- a/src/components/bottomSheetScrollable/types.d.ts
+++ b/src/components/bottomSheetScrollable/types.d.ts
@@ -6,7 +6,6 @@ import type {
   RefObject,
 } from 'react';
 import type {
-  ScrollView,
   VirtualizedListProps,
   ScrollViewProps,
   FlatListProps,

--- a/src/components/bottomSheetScrollable/types.d.ts
+++ b/src/components/bottomSheetScrollable/types.d.ts
@@ -15,6 +15,7 @@ import type {
   View,
   ScrollViewComponent,
   NodeHandle,
+  ScrollResponderMixin,
 } from 'react-native';
 import type Animated from 'react-native-reanimated';
 import type { ScrollEventsHandlersHookType } from '../../types';
@@ -114,7 +115,7 @@ export interface BottomSheetFlatListMethods {
   /**
    * Provides a handle to the underlying scroll responder.
    */
-  getScrollResponder: () => ReactNode | null | undefined;
+  getScrollResponder: () => ScrollResponderMixin | null | undefined;
 
   /**
    * Provides a reference to the underlying host component
@@ -175,7 +176,7 @@ export interface BottomSheetScrollViewMethods {
    * implement this method so that they can be composed while providing access
    * to the underlying scroll responder's methods.
    */
-  getScrollResponder(): ReactNode;
+  getScrollResponder(): ScrollResponderMixin;
 
   getScrollableNode(): any;
 
@@ -231,7 +232,7 @@ export interface BottomSheetSectionListMethods {
   /**
    * Provides a handle to the underlying scroll responder.
    */
-  getScrollResponder(): ScrollView | undefined;
+  getScrollResponder(): ScrollResponderMixin | undefined;
 
   /**
    * Provides a handle to the underlying scroll node.


### PR DESCRIPTION


## Motivation

The scroll responders were typed as `ReactNode` which only were usable because `ReactNode` includes `{}` i.e. any non-nullish value. From [React 18 going forward this is no longer the case](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210) so the types became unusable.

I'm not sure if it actually returned a `ScrollResponderMixin` in 0.62. [Earliest (similar) usage of `getScrollResponder: () => ScrollResponderMixin ` was in 0.63](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7be465810096380d994b685fc7dcde874a0ba47c/types/react-native/v0.63/index.d.ts#L6767).

