### PR TITLE
Fix reanimated freezing Keyboard module

### DIFF
--- a/src/hooks/useGestureEventsHandlersDefault.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.tsx
@@ -31,6 +31,8 @@ const INITIAL_CONTEXT: GestureEventContextType = {
   isScrollablePositionLocked: false,
 };
 
+const dismissKeyboardOnJs = runOnJS(Keyboard.dismiss);
+
 const resetContext = (context: any) => {
   'worklet';
   Object.keys(context).map(key => {
@@ -318,7 +320,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
               absoluteY > WINDOW_HEIGHT - animatedKeyboardHeight.value
             )
           ) {
-            runOnJS(Keyboard.dismiss)();
+            dismissKeyboardOnJs();
           }
         }
 

--- a/src/hooks/useGestureEventsHandlersDefault.web.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.web.tsx
@@ -30,6 +30,8 @@ const INITIAL_CONTEXT: GestureEventContextType = {
   isScrollablePositionLocked: false,
 };
 
+const dismissKeyboardOnJs = runOnJS(Keyboard.dismiss);
+
 const resetContext = (context: any) => {
   'worklet';
   Object.keys(context).map(key => {
@@ -312,7 +314,7 @@ export const useGestureEventsHandlersDefault = () => {
             absoluteY > WINDOW_HEIGHT - animatedKeyboardHeight.value
           )
         ) {
-          runOnJS(Keyboard.dismiss)();
+          dismissKeyboardOnJs();
         }
       }
 


### PR DESCRIPTION
## Motivation

Reanimated captures and freezes the whole Keyboard module since we reference it from a worklet. To avoid this we can create the function only once at the top of the module from the JS context. This seems to happen only with reanimated v3.