### PR TITLE
fix: keyboard dismiss with react-native-reanimated@3

### DIFF
--- a/src/hooks/useGestureEventsHandlersDefault.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.tsx
@@ -225,6 +225,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
           animatedScrollableContentOffsetY,
         ]
       );
+    const dismissKeyboard = () => Keyboard.dismiss()
     const handleOnEnd: GestureEventHandlerCallbackType<GestureEventContextType> =
       useWorkletCallback(
         function handleOnEnd(
@@ -296,7 +297,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
                 absoluteY > WINDOW_HEIGHT - animatedKeyboardHeight.value
               )
             ) {
-              runOnJS(Keyboard.dismiss)();
+              runOnJS(dismissKeyboard)();
             }
           }
 


### PR DESCRIPTION
react-native-reanimated version 3 [does not support](https://github.com/software-mansion/react-native-reanimated/issues/4177) passing certain objects to worklets.

The following error occurs, when you swipe to dismiss a Bottom Sheet with a BottomSheetTextInput focused:

```js
 LOG  Error: Trying to access property `dismiss` of an object which cannot be sent to the UI runtime.
    at get (/node_modules/react-native-reanimated/src/reanimated2/shareables.ts:69:26)
    at handleOnEnd (/node_modules/@gorhom/bottom-sheet/src/hooks/useGestureEventsHandlersDefault.tsx:299:31)
    at anonymous (/node_modules/@gorhom/bottom-sheet/src/hooks/useGestureHandler.ts:59:20)
    at anonymous (/node_modules/react-native-reanimated/src/reanimated2/hook/useAnimatedGestureHandler.ts:69:21)
    at handleAndFlushAnimationFrame (/node_modules/react-native-reanimated/src/reanimated2/core.ts:123:17)
    at apply (native)
    at callGuardDEV (worklet_1892348396866:3:7)
```

To fix this issue the dismiss function needs to be wrapped that can be sent to the worklet:
```js
const dismissKeyboard = () => Keyboard.dismiss()

...

runOnJS(dismissKeyboard)();
```