### PR TITLE
fix: crash on swipe down

### DIFF
--- a/src/hooks/useGestureEventsHandlersDefault.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.tsx
@@ -298,7 +298,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
                 absoluteY > WINDOW_HEIGHT - animatedKeyboardHeight.value
               )
             ) {
-              runOnJS(dismissKeyboard)
+              runOnJS(dismissKeyboard)();
             }
           }
 

--- a/src/hooks/useGestureEventsHandlersDefault.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.tsx
@@ -21,6 +21,7 @@ type GestureEventContextType = {
   isScrollablePositionLocked: boolean;
 };
 
+const dismissKeyboard = Keyboard.dismiss
 
 export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
   () => {
@@ -297,7 +298,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
                 absoluteY > WINDOW_HEIGHT - animatedKeyboardHeight.value
               )
             ) {
-              runOnJS(Keyboard.dismiss);
+              runOnJS(dismissKeyboard)
             }
           }
 

--- a/src/hooks/useGestureEventsHandlersDefault.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.tsx
@@ -21,7 +21,6 @@ type GestureEventContextType = {
   isScrollablePositionLocked: boolean;
 };
 
-const dismissKeyboardOnJs = runOnJS(Keyboard.dismiss);
 
 export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
   () => {
@@ -298,7 +297,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
                 absoluteY > WINDOW_HEIGHT - animatedKeyboardHeight.value
               )
             ) {
-              dismissKeyboardOnJs();
+              runOnJS(Keyboard.dismiss);
             }
           }
 


### PR DESCRIPTION
this PR fixes the issue faced here: 
https://github.com/gorhom/react-native-bottom-sheet/issues/1366

## Motivation

keyboard close was being called incorrectly which was causing a crash on the device.
This fix was tested on device

