### PR TITLE
fix: Case to prevent Android sheet from reopening using 100% detent

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1284,15 +1284,28 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     useAnimatedReaction(
       () => ({
         snapPoints: animatedSnapPoints.value,
+        providedSnapPoints: ('value' in _providedSnapPoints
+          ? _providedSnapPoints.value
+          : _providedSnapPoints),
         containerHeight: animatedContainerHeight.value,
+        keyboardInputMode: android_keyboardInputMode,
       }),
       (result, _previousResult) => {
-        const { snapPoints, containerHeight } = result;
-        const _previousSnapPoints = _previousResult?.snapPoints;
+        const { 
+          snapPoints,
+          providedSnapPoints,
+          containerHeight,
+          keyboardInputMode
+        } = result;        const _previousSnapPoints = _previousResult?.snapPoints;
         const _previousContainerHeight = _previousResult?.containerHeight;
 
         if (
-          JSON.stringify(snapPoints) === JSON.stringify(_previousSnapPoints) ||
+          (JSON.stringify(snapPoints) === JSON.stringify(_previousSnapPoints) &&
+          Platform.OS !== "android") ||
+          (JSON.stringify(snapPoints) === JSON.stringify(_previousSnapPoints) &&
+          Platform.OS === "android" &&
+          keyboardInputMode === KEYBOARD_INPUT_MODE.adjustResize &&
+          providedSnapPoints.indexOf("100%") === -1) ||
           !isLayoutCalculated.value ||
           !isAnimatedOnMount.value ||
           containerHeight <= 0


### PR DESCRIPTION
Please see full detail of the bug addressed here: https://github.com/gorhom/react-native-bottom-sheet/issues/1374

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

On Android specifically, the Sheet would intermittently re-open after closing it in the following scenario:

Keyboard is open
Detent is 100%
This was an issue within the @gorhom/bottom-sheet library where the function normalizeSnapPoints would not change the true pixel value of a 100% detent. It always equates to 0. This is specific to Android with adjustResize as the keyboard behaviour.

A condition was added as a patch to prevent exiting a function (onSnapPointsChange) which allows the Sheet to react to snap point changes mid-animation.
