### PR TITLE
mock BottomSheet list with ReactNative list equivalent

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -9,6 +9,7 @@
  */
 
 const React = require('react');
+const ReactNative = require('react-native');
 
 const NOOP = () => {};
 const NOOP_VALUE = { value: 0 };
@@ -104,10 +105,10 @@ const useBottomSheetDynamicSnapPoints = () => ({
 
 module.exports = {
   BottomSheetView: BottomSheetComponent,
-  BottomSheetScrollView: BottomSheetComponent,
-  BottomSheetSectionList: BottomSheetComponent,
-  BottomSheetFlatList: BottomSheetComponent,
-  BottomSheetVirtualizedList: BottomSheetComponent,
+  BottomSheetScrollView: ReactNative.ScrollView,
+  BottomSheetSectionList: ReactNative.SectionList,
+  BottomSheetFlatList: ReactNative.FlatList,
+  BottomSheetVirtualizedList: ReactNative.VirtualizedList,
 
   BottomSheetModalProvider,
   BottomSheetModal,


### PR DESCRIPTION
## Motivation

In react-native, if we run test on component where we use `BottomSheetScrollView` / `BottomSheetSectionList` / `BottomSheetFlatList` `BottomSheetVirtualizedList` with `@gorhom/bottom-sheet/mock` mock, It doesn't work. The content of these components is not rendered. 

That's because these components are replaced by `BottomSheetComponent` which does not implement `renderItem` props.

## Solution

Using react-native components is equivalent to solving the above-mentioned problem.
