### PR TITLE
fix: keyboard on focus

### DIFF
--- a/src/components/bottomSheetContainer/BottomSheetContainer.tsx
+++ b/src/components/bottomSheetContainer/BottomSheetContainer.tsx
@@ -54,7 +54,7 @@ function BottomSheetContainerComponent({
             right: 0,
             bottom: Math.max(
               0,
-              WINDOW_HEIGHT - (pageY + height + (StatusBar.currentHeight ?? 0))
+              WINDOW_HEIGHT - ((pageY ?? 0) + height + (StatusBar.currentHeight ?? 0))
             ),
           };
         }

--- a/src/components/bottomSheetContainer/BottomSheetContainer.tsx
+++ b/src/components/bottomSheetContainer/BottomSheetContainer.tsx
@@ -49,7 +49,7 @@ function BottomSheetContainerComponent({
       containerRef.current?.measure(
         (_x, _y, _width, _height, _pageX, pageY) => {
           containerOffset.value = {
-            top: pageY,
+            top: pageY ?? 0,
             left: 0,
             right: 0,
             bottom: Math.max(


### PR DESCRIPTION
Fixes: #1328 

## Motivation
Sometimes, especially when the view is newly created `measure` function return undefined on `PageY` that was causing hiding modal behind the keyboard as  `animatedContainerOffset.value.bottom` was `NaN` in `BottomSheet.tsx` file
<img width="945" alt="image" src="https://github.com/gorhom/react-native-bottom-sheet/assets/40486471/440101d6-0fa8-4d10-9e58-3a7b2f5ba9d1">

With this change, I'm passing the default value 0 so that it will not have the bug.

With the current change, everything is working fine on both platforms.

Thanks