### PR TITLE
fix: always pass ref object to mountSheet

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -10,7 +10,7 @@ import React, {
 import { Portal, usePortal } from '@gorhom/portal';
 import BottomSheet from '../bottomSheet';
 import { useBottomSheetModalInternal } from '../../hooks';
-import { print } from '../../utilities';
+import { print, isFunction } from '../../utilities';
 import {
   DEFAULT_STACK_BEHAVIOR,
   DEFAULT_ENABLE_DISMISS_ON_CLOSE,
@@ -71,6 +71,7 @@ const BottomSheetModalComponent = forwardRef<
   //#endregion
 
   //#region refs
+  const internalRef = useRef<BottomSheetModal | null>(null);
   const bottomSheetRef = useRef<BottomSheet>(null);
   const currentIndexRef = useRef(!animateOnMount ? index : -1);
   const restoreIndexRef = useRef(-1);
@@ -78,6 +79,16 @@ const BottomSheetModalComponent = forwardRef<
   const forcedDismissed = useRef(false);
   const mounted = useRef(false);
   mounted.current = mount;
+
+  const handleRef = (newRef: BottomSheetModal) => {
+    if (isFunction(ref)) {
+      ref(newRef);
+    } else if (ref) {
+      ref.current = newRef;
+    }
+
+    internalRef.current = newRef;
+  };
   //#endregion
 
   //#region variables
@@ -183,7 +194,7 @@ const BottomSheetModalComponent = forwardRef<
           mount: true,
           data: _data,
         });
-        mountSheet(key, ref, stackBehavior);
+        mountSheet(key, internalRef, stackBehavior);
 
         print({
           component: BottomSheetModal.name,
@@ -349,7 +360,7 @@ const BottomSheetModalComponent = forwardRef<
   //#endregion
 
   //#region expose methods
-  useImperativeHandle(ref, () => ({
+  useImperativeHandle(handleRef, () => ({
     // sheet
     snapToIndex: handleSnapToIndex,
     snapToPosition: handleSnapToPosition,

--- a/src/utilities/getRefNativeTag.ts
+++ b/src/utilities/getRefNativeTag.ts
@@ -1,4 +1,4 @@
-const isFunction = (ref: unknown): ref is Function => typeof ref === 'function';
+import { isFunction } from './isFunction';
 
 const hasNativeTag = (
   ref: unknown

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -3,3 +3,4 @@ export { animate } from './animate';
 export { getKeyboardAnimationConfigs } from './getKeyboardAnimationConfigs';
 export { print } from './logger';
 export { noop, workletNoop } from './noop';
+export { isFunction } from './isFunction';

--- a/src/utilities/isFunction.ts
+++ b/src/utilities/isFunction.ts
@@ -1,0 +1,2 @@
+export const isFunction = (ref: unknown): ref is Function =>
+  typeof ref === 'function';


### PR DESCRIPTION
Motivation
----------

This pull request addresses an issue encountered while using the `useBottomSheetModal` hook in conjunction with a wrapper around the bottom sheet component. The wrapper relies on the `forwardRef` functionality and requires access to the bottom sheet's ref. However, a problem arises when utilizing the `BottomSheetModalProvider`, specifically in the `handleMountSheet` function. This function pushes new sheets to an array that tracks all open sheets, which can then be utilized by the `handleDismiss` and `handleDismissAll` methods. The issue stems from the assumption that the refs stored in the objects within the `sheetsQueueRef` are always objects.

Upon investigation, it became apparent that invoking `dismiss` or `dismissAll` through the `useBottomSheetModal` hook had no effect within our app. A closer examination revealed that the line `sheetToBeDismissed.ref?.current?.dismiss();` failed silently due to the presence of `?.current` since our `sheetToBeDismissed.ref` resolved to a function instead of a `Ref` object.

Solution
--------

This pull request resolves the aforementioned issue by encapsulating the incoming ref from `forwardRef` and creating a callback function that is passed to `useImperativeHandle`. This approach ensures that the forward `ref` and the new `internalRef` remain synchronized. Consequently, the `internalRef` is then used in `mountSheet`, guaranteeing that a ref object is consistently stored within the `sheetsQueueRef` array.