### PR TITLE
fix: invalid prop type

### DIFF
--- a/docs/props.md
+++ b/docs/props.md
@@ -200,7 +200,7 @@ Defines the keyboard appearance behavior.
 
 | type                                      | default       | required |
 | ----------------------------------------- | ------------- | -------- |
-| 'extend' \| 'fullScreen' \| 'interactive' | 'interactive' | NO       |
+| 'extend' \| 'fillParent' \| 'interactive' | 'interactive' | NO       |
 
 ### `keyboardBlurBehavior`
 


### PR DESCRIPTION
The `fillParent` prop type of the BottomSheet component is typed as `fullScreen` in the docs, which is inconsistent with the existing code.

This PR fixes the 'typo'