### PR TITLE
fix: upgraded example' expo version to support web demo.

### DIFF
--- a/example/app/src/App.tsx
+++ b/example/app/src/App.tsx
@@ -2,8 +2,10 @@ import React, { useMemo } from 'react';
 import { StyleSheet } from 'react-native';
 import { ShowcaseApp } from '@gorhom/showcase-template';
 import { screens as defaultScreens } from './screens';
-import { version, description } from '../../../package.json';
+import packageJson from '../../../package.json';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+
+const { version, description } = packageJson;
 
 const author = {
   username: 'Mo Gorhom',

--- a/example/expo/package.json
+++ b/example/expo/package.json
@@ -12,6 +12,7 @@
     "eject": "expo eject"
   },
   "dependencies": {
+    "@expo/webpack-config": "^18.1.1",
     "@gorhom/portal": "^1.0.13",
     "@gorhom/showcase-template": "^2.1.0",
     "@react-navigation/bottom-tabs": "^6.3.1",
@@ -20,29 +21,28 @@
     "@react-navigation/native": "^6.0.10",
     "@react-navigation/native-stack": "^6.6.2",
     "@react-navigation/stack": "^6.2.1",
-    "expo": "^46.0.0",
-    "expo-status-bar": "~1.4.0",
+    "expo": "^49.0.0",
+    "expo-status-bar": "~1.6.0",
     "faker": "^4.1.0",
     "nanoid": "^3.3.3",
-    "react": "18.0.0",
-    "react-dom": "18.0.0",
-    "react-native": "0.69.4",
-    "react-native-gesture-handler": "~2.5.0",
-    "react-native-pager-view": "5.4.24",
-    "react-native-reanimated": "~2.9.1",
-    "react-native-redash": "^16.2.4",
-    "react-native-safe-area-context": "4.3.1",
-    "react-native-screens": "~3.15.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.72.3",
+    "react-native-gesture-handler": "~2.12.0",
+    "react-native-pager-view": "6.2.0",
+    "react-native-reanimated": "~3.3.0",
+    "react-native-redash": "^18.1.0",
+    "react-native-safe-area-context": "4.6.3",
+    "react-native-screens": "~3.22.0",
     "react-native-tab-view": "^3.1.1",
-    "react-native-web": "~0.18.7"
+    "react-native-web": "~0.19.6"
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",
-    "@types/react": "~18.0.0",
+    "@types/react": "~18.2.14",
     "@types/react-native": "~0.69.1",
     "babel-plugin-module-resolver": "^4.1.0",
-    "expo-cli": "^6.0.2",
-    "typescript": "^4.6.3"
+    "typescript": "^5.1.3"
   },
   "resolutions": {
     "@babel/core": "^7.18.0",

--- a/src/utilities/getRefNativeTag.ts
+++ b/src/utilities/getRefNativeTag.ts
@@ -1,3 +1,5 @@
+import { Platform } from 'react-native';
+
 const isFunction = (ref: unknown): ref is Function => typeof ref === 'function';
 
 const hasNativeTag = (
@@ -28,10 +30,13 @@ export function getRefNativeTag(ref: unknown) {
   }
 
   if (!nativeTag || typeof nativeTag !== 'number') {
+    if (Platform.OS === 'web') {
+      return 0;
+    }
     throw new Error(
-      `Unexpected nativeTag: ${refType}; nativeTag=${nativeTag} 
+      `Unexpected nativeTag: ${refType}; nativeTag=${nativeTag}
 
-			createBottomSheetScrollableComponent's ScrollableComponent needs to return 
+			createBottomSheetScrollableComponent's ScrollableComponent needs to return
 			a reference that contains a nativeTag to a Native HostComponent.
 
 			ref=${ref}


### PR DESCRIPTION
Upgraded expo version of expo example to support web demo.
![image](https://github.com/gorhom/react-native-bottom-sheet/assets/32405058/9e3126cf-cd9d-4dd7-94a7-3fa14de22fdb)
