### PR TITLE
fix: [v5]fix backdrop gesture

### DIFF
--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -1,17 +1,12 @@
 import React, { memo, useCallback, useMemo, useState } from 'react';
-import { ViewProps } from 'react-native';
+import { Pressable, ViewProps } from 'react-native';
 import Animated, {
   interpolate,
   Extrapolate,
   useAnimatedStyle,
   useAnimatedReaction,
-  useAnimatedGestureHandler,
   runOnJS,
 } from 'react-native-reanimated';
-import {
-  TapGestureHandler,
-  TapGestureHandlerGestureEvent,
-} from 'react-native-gesture-handler';
 import { useBottomSheet } from '../../hooks';
 import {
   DEFAULT_OPACITY,
@@ -22,6 +17,8 @@ import {
 } from './constants';
 import { styles } from './styles';
 import type { BottomSheetDefaultBackdropProps } from './types';
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 const BottomSheetBackdropComponent = ({
   animatedIndex,
@@ -73,18 +70,6 @@ const BottomSheetBackdropComponent = ({
   );
   //#endregion
 
-  //#region tap gesture
-  const gestureHandler =
-    useAnimatedGestureHandler<TapGestureHandlerGestureEvent>(
-      {
-        onFinish: () => {
-          runOnJS(handleOnPress)();
-        },
-      },
-      [handleOnPress]
-    );
-  //#endregion
-
   //#region styles
   const containerAnimatedStyle = useAnimatedStyle(() => ({
     opacity: interpolate(
@@ -115,20 +100,19 @@ const BottomSheetBackdropComponent = ({
   //#endregion
 
   return pressBehavior !== 'none' ? (
-    <TapGestureHandler onGestureEvent={gestureHandler}>
-      <Animated.View
-        style={containerStyle}
-        pointerEvents={pointerEvents}
-        accessible={true}
-        accessibilityRole="button"
-        accessibilityLabel="Bottom Sheet backdrop"
-        accessibilityHint={`Tap to ${
-          typeof pressBehavior === 'string' ? pressBehavior : 'move'
-        } the Bottom Sheet`}
-      >
-        {children}
-      </Animated.View>
-    </TapGestureHandler>
+    <AnimatedPressable
+      onPress={handleOnPress}
+      style={containerStyle}
+      pointerEvents={pointerEvents}
+      accessible={true}
+      accessibilityRole="button"
+      accessibilityLabel="Bottom Sheet backdrop"
+      accessibilityHint={`Tap to ${
+        typeof pressBehavior === 'string' ? pressBehavior : 'move'
+      } the Bottom Sheet`}
+    >
+      {children}
+    </AnimatedPressable>
   ) : (
     <Animated.View pointerEvents={pointerEvents} style={containerStyle}>
       {children}


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation
Fixes #1465 

1. Using the `BottomSheetBackdrop` component on web with latest v5 alpha 3 causes the following error:
`Uncaught TypeError: Cannot read properties of undefined (reading 'toString')`. 
This is due to an issue with `useAnimatedGestureHandler` and babel. You can read more here: https://github.com/software-mansion/react-native-reanimated/issues/2435

2. You can avoid this issue by following this solution -> https://github.com/software-mansion/react-native-reanimated/issues/2994#issuecomment-1216482813
 While this removes the error and backdrop shows fine, there is another issue:
 - the tap gesture does not work on web and the `handleOnPress` does not get called

Since we already call `runOnJs` and it is more effort I guess to go from the ui thread and call from js thread, we can just use an Animated Pressable and pass it on onPress.

This will fix the uncalled onPress and remove the error so users of the lib dont have to do workarounds
