### PR TITLE
fix(BottomSheetTextInput): reset shouldHandleKeyboardEvents on unmount

### DIFF
--- a/src/components/bottomSheetTextInput/BottomSheetTextInput.tsx
+++ b/src/components/bottomSheetTextInput/BottomSheetTextInput.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, forwardRef } from 'react';
+import React, { memo, useCallback, forwardRef, useEffect } from 'react';
 import { TextInput } from 'react-native-gesture-handler';
 import { useBottomSheetInternal } from '../../hooks';
 import type { BottomSheetTextInputProps } from './types';
@@ -9,6 +9,13 @@ const BottomSheetTextInputComponent = forwardRef<
 >(({ onFocus, onBlur, ...rest }, ref) => {
   //#region hooks
   const { shouldHandleKeyboardEvents } = useBottomSheetInternal();
+
+  useEffect(() => {
+    return () => {
+      // Reset the flag on unmount
+      shouldHandleKeyboardEvents.value = false;
+    };
+  }, [shouldHandleKeyboardEvents]);
   //#endregion
 
   //#region callbacks


### PR DESCRIPTION
This pull-request resets shouldHandleKeyboardEvents flag on BottomSheetTextInput unmount

## Motivation
For my project, I'm using a system where I'm reusing a single BottomSheet and I'm mounting and unmounting the content (can be different) as it opens and closes.

This approach triggers the following issue: often, when I unmount the content of the BottomSheet and a BottomSheetTextInput is focused, the blur event doesn't get handled at all, and this causes the BottomSheet to show up whenever I open a keyboard from an unrelated place. 

The fix is simple: I just reset the flag whenever an unmount happens.

### Before
https://github.com/gorhom/react-native-bottom-sheet/assets/2735681/73928969-427c-4cca-9a96-687567e3d05a

### After
https://github.com/gorhom/react-native-bottom-sheet/assets/2735681/2ea03359-1dd5-4cf1-bebc-3ff733e30e93

