### PR TITLE
fix: non-zero duration for resize animation

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1360,7 +1360,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           if (containerHeight !== _previousContainerHeight) {
             animationSource = ANIMATION_SOURCE.CONTAINER_RESIZE;
             animationConfig = {
-              duration: 0,
+              duration: 1,
             };
           }
         }


### PR DESCRIPTION
## Motivation

When the user focuses a text input, either inside or outside a bottom sheet modal, the container resizes on Android.

Starting with Reanimated v3, if the modal itself is shorter than the keyboard, the resize animation causes the whole sheet to call disappear. This happens both in v4 and v5-alpha.3.

To be more specific, using Reanimated v3 [this code](https://github.com/gorhom/react-native-bottom-sheet/blob/master/src/components/bottomSheet/BottomSheet.tsx#L306) evaluates to `true` for a moment and the sheet closes.

I introduced a 1ms delay in the resize animation, which solves this issue. I am not completely sure on the exact reason, considering that the difference is most likely in the Reanimated source.

This PR fixes #1356.

