### PR TITLE
Eli nathan/dynamic size bottom sheet with max height

### DIFF
--- a/example/app/src/screens/advanced/DynamicSnapPointExample.tsx
+++ b/example/app/src/screens/advanced/DynamicSnapPointExample.tsx
@@ -20,7 +20,8 @@ const DynamicSnapPointExample = () => {
     animatedSnapPoints,
     animatedContentHeight,
     handleContentLayout,
-  } = useBottomSheetDynamicSnapPoints(initialSnapPoints);
+    childViewMaxHeightStyle,
+  } = useBottomSheetDynamicSnapPoints(initialSnapPoints, '90%');
 
   // callbacks
   const handleIncreaseContentPress = useCallback(() => {
@@ -40,9 +41,10 @@ const DynamicSnapPointExample = () => {
   const contentContainerStyle = useMemo(
     () => [
       styles.contentContainerStyle,
+      childViewMaxHeightStyle,
       { paddingBottom: safeBottomArea || 6 },
     ],
-    [safeBottomArea]
+    [safeBottomArea, childViewMaxHeightStyle]
   );
   const emojiContainerStyle = useMemo(
     () => ({

--- a/example/app/src/screens/advanced/DynamicSnapPointExample.tsx
+++ b/example/app/src/screens/advanced/DynamicSnapPointExample.tsx
@@ -39,20 +39,14 @@ const DynamicSnapPointExample = () => {
 
   // styles
   const contentContainerStyle = useMemo(
-    () => [
-      styles.contentContainerStyle,
-      childViewMaxHeightStyle,
-      { paddingBottom: safeBottomArea || 6 },
-    ],
-    [safeBottomArea, childViewMaxHeightStyle]
+    () => [styles.contentContainerStyle, childViewMaxHeightStyle],
+    [childViewMaxHeightStyle]
   );
-  const emojiContainerStyle = useMemo(
-    () => ({
-      ...styles.emojiContainer,
-      height: 50 * count,
-    }),
-    [count]
+  const contentStyle = useMemo(
+    () => [{ paddingBottom: safeBottomArea || 6 }],
+    [safeBottomArea]
   );
+  const emojisToShow = [...Array(count)].map((_, i) => i);
 
   // renders
   return (
@@ -71,14 +65,18 @@ const DynamicSnapPointExample = () => {
           style={contentContainerStyle}
           onLayout={handleContentLayout}
         >
-          <Text style={styles.message}>
-            Could this sheet resize to its content height ?
-          </Text>
-          <View style={emojiContainerStyle}>
-            <Text style={styles.emoji}>😍</Text>
+          <View style={contentStyle}>
+            <Text style={styles.message}>
+              Could this sheet resize to its content height ?
+            </Text>
+            <Button label="Yes" onPress={handleIncreaseContentPress} />
+            <Button label="Maybe" onPress={handleDecreaseContentPress} />
+            {emojisToShow.map((_, i) => (
+              <View key={i} style={styles.emojiContainer}>
+                <Text style={styles.emoji}>😍</Text>
+              </View>
+            ))}
           </View>
-          <Button label="Yes" onPress={handleIncreaseContentPress} />
-          <Button label="Maybe" onPress={handleDecreaseContentPress} />
         </BottomSheetScrollView>
       </BottomSheet>
     </View>
@@ -91,6 +89,7 @@ const styles = StyleSheet.create({
     padding: 24,
   },
   contentContainerStyle: {
+    flex: 1,
     paddingTop: 12,
     paddingBottom: 6,
     paddingHorizontal: 24,
@@ -102,13 +101,16 @@ const styles = StyleSheet.create({
     color: 'black',
   },
   emoji: {
-    fontSize: 156,
+    fontSize: 40,
     textAlign: 'center',
     alignSelf: 'center',
   },
   emojiContainer: {
     overflow: 'hidden',
+    borderRadius: 8,
     justifyContent: 'center',
+    backgroundColor: '#e1e1e1',
+    marginVertical: 12,
   },
 });
 

--- a/example/app/src/screens/advanced/DynamicSnapPointExample.tsx
+++ b/example/app/src/screens/advanced/DynamicSnapPointExample.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import BottomSheet, {
-  BottomSheetView,
+  BottomSheetScrollView,
   useBottomSheetDynamicSnapPoints,
 } from '@gorhom/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -21,7 +21,7 @@ const DynamicSnapPointExample = () => {
     animatedContentHeight,
     handleContentLayout,
     childViewMaxHeightStyle,
-  } = useBottomSheetDynamicSnapPoints(initialSnapPoints, '90%');
+  } = useBottomSheetDynamicSnapPoints(initialSnapPoints, '70%');
 
   // callbacks
   const handleIncreaseContentPress = useCallback(() => {
@@ -67,7 +67,7 @@ const DynamicSnapPointExample = () => {
         enablePanDownToClose={true}
         animateOnMount={true}
       >
-        <BottomSheetView
+        <BottomSheetScrollView
           style={contentContainerStyle}
           onLayout={handleContentLayout}
         >
@@ -79,7 +79,7 @@ const DynamicSnapPointExample = () => {
           </View>
           <Button label="Yes" onPress={handleIncreaseContentPress} />
           <Button label="Maybe" onPress={handleDecreaseContentPress} />
-        </BottomSheetView>
+        </BottomSheetScrollView>
       </BottomSheet>
     </View>
   );

--- a/example/app/src/screens/advanced/DynamicSnapPointExample.tsx
+++ b/example/app/src/screens/advanced/DynamicSnapPointExample.tsx
@@ -89,7 +89,6 @@ const styles = StyleSheet.create({
     padding: 24,
   },
   contentContainerStyle: {
-    flex: 1,
     paddingTop: 12,
     paddingBottom: 6,
     paddingHorizontal: 24,

--- a/example/app/src/screens/modal/DynamicSnapPointExample.tsx
+++ b/example/app/src/screens/modal/DynamicSnapPointExample.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import {
   BottomSheetModal,
-  BottomSheetView,
+  BottomSheetScrollView,
   useBottomSheetDynamicSnapPoints,
 } from '@gorhom/bottom-sheet';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -22,7 +22,8 @@ const DynamicSnapPointExample = () => {
     animatedSnapPoints,
     animatedContentHeight,
     handleContentLayout,
-  } = useBottomSheetDynamicSnapPoints(initialSnapPoints);
+    childViewMaxHeightStyle,
+  } = useBottomSheetDynamicSnapPoints(initialSnapPoints, '70%');
 
   // callbacks
   const handleIncreaseContentPress = useCallback(() => {
@@ -31,7 +32,6 @@ const DynamicSnapPointExample = () => {
   const handleDecreaseContentPress = useCallback(() => {
     setCount(state => Math.max(state - 1, 0));
   }, []);
-
   const handlePresentPress = useCallback(() => {
     bottomSheetRef.current?.present();
   }, []);
@@ -41,19 +41,14 @@ const DynamicSnapPointExample = () => {
 
   // styles
   const contentContainerStyle = useMemo(
-    () => ({
-      ...styles.contentContainerStyle,
-      paddingBottom: safeBottomArea || 6,
-    }),
+    () => [styles.contentContainerStyle, childViewMaxHeightStyle],
+    [childViewMaxHeightStyle]
+  );
+  const contentStyle = useMemo(
+    () => [{ paddingBottom: safeBottomArea || 6 }],
     [safeBottomArea]
   );
-  const emojiContainerStyle = useMemo(
-    () => ({
-      ...styles.emojiContainer,
-      height: 50 * count,
-    }),
-    [count]
-  );
+  const emojisToShow = [...Array(count)].map((_, i) => i);
 
   // renders
   return (
@@ -66,20 +61,25 @@ const DynamicSnapPointExample = () => {
         handleHeight={animatedHandleHeight}
         contentHeight={animatedContentHeight}
         enablePanDownToClose={true}
+        animateOnMount={true}
       >
-        <BottomSheetView
+        <BottomSheetScrollView
           style={contentContainerStyle}
           onLayout={handleContentLayout}
         >
-          <Text style={styles.message}>
-            Could this sheet modal resize to its content height ?
-          </Text>
-          <View style={emojiContainerStyle}>
-            <Text style={styles.emoji}>😍</Text>
+          <View style={contentStyle}>
+            <Text style={styles.message}>
+              Could this sheet resize to its content height ?
+            </Text>
+            <Button label="Yes" onPress={handleIncreaseContentPress} />
+            <Button label="Maybe" onPress={handleDecreaseContentPress} />
+            {emojisToShow.map((_, i) => (
+              <View key={i} style={styles.emojiContainer}>
+                <Text style={styles.emoji}>😍</Text>
+              </View>
+            ))}
           </View>
-          <Button label="Yes" onPress={handleIncreaseContentPress} />
-          <Button label="Maybe" onPress={handleDecreaseContentPress} />
-        </BottomSheetView>
+        </BottomSheetScrollView>
       </BottomSheetModal>
     </View>
   );
@@ -102,13 +102,16 @@ const styles = StyleSheet.create({
     color: 'black',
   },
   emoji: {
-    fontSize: 156,
+    fontSize: 40,
     textAlign: 'center',
     alignSelf: 'center',
   },
   emojiContainer: {
     overflow: 'hidden',
+    borderRadius: 8,
     justifyContent: 'center',
+    backgroundColor: '#e1e1e1',
+    marginVertical: 12,
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   },
   "dependencies": {
     "@gorhom/portal": "1.0.14",
-    "invariant": "^2.2.4"
+    "invariant": "^2.2.4",
+    "react-native-safe-area-context": "^4.7.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",

--- a/src/hooks/useBottomSheetDynamicSnapPoints.ts
+++ b/src/hooks/useBottomSheetDynamicSnapPoints.ts
@@ -4,22 +4,28 @@ import {
   INITIAL_HANDLE_HEIGHT,
   INITIAL_SNAP_POINT,
 } from '../components/bottomSheet/constants';
+import useBottomSheetMaxHeight from './useBottomSheetMaxHeight';
 
 /**
  * Provides dynamic content height calculating functionalities, by
  * replacing the placeholder `CONTENT_HEIGHT` with calculated layout.
+ * If max height is supplied, the sheet will be dynamic height up to the defined maximum.
+ * Max height works best when "CONTENT_HEIGHT" is supplied as the final or only snapPoint
  * @example
- * [0, 'CONTENT_HEIGHT', '100%']
+ * useBottomSheetDynamicSnapPoints([0, 'CONTENT_HEIGHT'], "80%")
  * @param initialSnapPoints your snap point with content height placeholder.
+ * @param maxHeight A percentage string or number value to be used as a maximum height for dynamic snap points.
  * @returns {
  *  - animatedSnapPoints: an animated snap points to be set on `BottomSheet` or `BottomSheetModal`.
  *  - animatedHandleHeight: an animated handle height callback node to be set on `BottomSheet` or `BottomSheetModal`.
  *  - animatedContentHeight: an animated content height callback node to be set on `BottomSheet` or `BottomSheetModal`.
  *  - handleContentLayout: a `onLayout` callback method to be set on `BottomSheetView` component.
+ *  - childViewMaxHeightStyle: a style prop that can applied to the BottomSheet's first child component to allow dynamic content height to be limited to a max height.
  * }
  */
 export const useBottomSheetDynamicSnapPoints = (
-  initialSnapPoints: Array<string | number>
+  initialSnapPoints: Array<string | number>,
+  maxHeight?: `${string}%` | number
 ) => {
   // variables
   const animatedContentHeight = useSharedValue(0);
@@ -56,10 +62,13 @@ export const useBottomSheetDynamicSnapPoints = (
     [animatedContentHeight]
   );
 
+  const childViewMaxHeightStyle = useBottomSheetMaxHeight(maxHeight);
+
   return {
     animatedSnapPoints,
     animatedHandleHeight,
     animatedContentHeight,
+    childViewMaxHeightStyle,
     handleContentLayout,
   };
 };

--- a/src/hooks/useBottomSheetMaxHeight.ts
+++ b/src/hooks/useBottomSheetMaxHeight.ts
@@ -1,0 +1,39 @@
+import { useWindowDimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+type MaxHeight = `${string}%` | number;
+
+const getPercentageMaxHeight = (
+  maxHeight: `${string}%`,
+  safeMaxheightValue: number
+) => {
+  return safeMaxheightValue * (parseFloat(maxHeight) / 100);
+};
+
+const getNumberMaxHeight = (maxHeight: number, safeMaxheightValue: number) => {
+  if (maxHeight > safeMaxheightValue) {
+    return safeMaxheightValue;
+  }
+  return maxHeight;
+};
+
+const useBottomSheetMaxHeight = (maxHeight?: MaxHeight) => {
+  const { height: deviceHeight } = useWindowDimensions();
+  const { top: topSafeAreaInset } = useSafeAreaInsets();
+  if (!maxHeight) {
+    return undefined;
+  }
+  const safeDeviceHeight = deviceHeight - topSafeAreaInset;
+  const maxHeightIsPercentage = typeof maxHeight === 'string';
+  const maxHeightNumber = maxHeightIsPercentage
+    ? getPercentageMaxHeight(maxHeight as `${string}%`, safeDeviceHeight)
+    : getNumberMaxHeight(maxHeight as number, safeDeviceHeight);
+
+  const childViewStyle = {
+    maxHeight: maxHeightNumber,
+  };
+
+  return childViewStyle;
+};
+
+export default useBottomSheetMaxHeight;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7789,6 +7789,11 @@ react-native-reanimated@^2.8.0:
     setimmediate "^1.0.5"
     string-hash-64 "^1.0.3"
 
+react-native-safe-area-context@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.7.2.tgz#1673aa99b6a9235e7faaf5a248e69795d6e54e07"
+  integrity sha512-5fy/hRNJ7bI/U2SliOeKf0D80J4lXPc1NsRiNS7Xaz8YTnqlzWib1ViItkwKPfufe54YKzVBMmM32RpdzvO2gg==
+
 react-native@^0.62.2:
   version "0.62.3"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.62.3.tgz#9a2e96af3dedd0723c8657831eec4ed3c30f3299"


### PR DESCRIPTION
Inspired by https://github.com/gorhom/react-native-bottom-sheet/pull/1402 @ororsatti
Adding a hook to have a sheet with a max height that will dynamically change its height until reaching the limit, following this discussion: https://github.com/gorhom/react-native-bottom-sheet/discussions/1363

- Added `useBottomSheetMaxHeight` hook
- Call above hook from `useBottomSheetDynamicSnapPoints`
- Updated the example to show the max height & scrolling functionality.
  - Example update also changes it from adding blank empty height to adding new rows of content 

Motivation
People are asking for this feature for a while now, and asked me in the discussion to share the code.
Closes: (https://github.com/gorhom/react-native-bottom-sheet/issues/658 , https://github.com/gorhom/react-native-bottom-sheet/issues/32)

## Example
<video src="https://github.com/gorhom/react-native-bottom-sheet/assets/32842898/dc0e9648-e679-48dd-8951-b9dc7009751e" />