### PR TITLE
fix: `dismissAll` not dismissing all bottom sheets

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -376,7 +376,7 @@ const BottomSheetModalComponent = forwardRef<
       handleOnUpdate={handlePortalRender}
       handleOnUnmount={handlePortalOnUnmount}
     >
-      <ContainerComponent>
+      <ContainerComponent key={key}>
         <BottomSheet
           {...bottomSheetProps}
           ref={bottomSheetRef}


### PR DESCRIPTION
## Motivation

Fixes a regression introduced in v4.4.8 from https://github.com/gorhom/react-native-bottom-sheet/pull/1309 that breaks `dismissAll` from the `useBottomSheetModal` hook when stacking multiple bottom sheet modals.

## Reproduction

- Run the example app
- Press `Stack Modals`
- Press multiple `Present Modal [A|B|C]` buttons to stack multiple bottom sheets
- Press `Dismiss All Modal` button

Fails to dismiss all bottom sheets

