### PR TITLE
add a few types to fix typescript errors

### DIFF
--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -42,7 +42,12 @@ export const useKeyboard = () => {
 
   //#region worklets
   const handleKeyboardEvent = useWorkletCallback(
-    (state, height, duration, easing) => {
+    (
+      state: KEYBOARD_STATE,
+      height: number,
+      duration: number,
+      easing: KeyboardEventEasing
+    ) => {
       if (state === KEYBOARD_STATE.SHOWN && !shouldHandleKeyboardEvents.value) {
         /**
          * if the keyboard event was fired before the `onFocus` on TextInput,


### PR DESCRIPTION
## Motivation

App using the default tsconfig will get 4 ts errors (on v4.5.1) because these params have to type (unknown) 
typescript will even show error in node_modules if the non transpiled ts files are published (even with skipLibCheck).
Adding the types will fix these issues for apps that have a strict ts config.

