### PR TITLE
feat: ability to enable ScrollableComponent NativeViewGestureHandler separately from DraggableView

### DIFF
--- a/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
+++ b/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
@@ -43,6 +43,8 @@ export function createBottomSheetScrollableComponent<T, P>(
       onScrollBeginDrag,
       onScrollEndDrag,
       onContentSizeChange,
+      //overrides
+      forceScrollOnGestureHandler,
       ...rest
     }: any = props;
 
@@ -69,6 +71,8 @@ export function createBottomSheetScrollableComponent<T, P>(
     //#endregion
 
     //#region variables
+    const scrollEnabled =
+      forceScrollOnGestureHandler || enableContentPanningGesture;
     const scrollableAnimatedProps = useAnimatedProps(
       () => ({
         decelerationRate:
@@ -131,7 +135,7 @@ export function createBottomSheetScrollableComponent<T, P>(
       const scrollableContent = (
         <NativeViewGestureHandler
           ref={nativeGestureRef}
-          enabled={enableContentPanningGesture}
+          enabled={scrollEnabled}
           shouldCancelWhenOutside={false}
         >
           <ScrollableComponent
@@ -178,7 +182,7 @@ export function createBottomSheetScrollableComponent<T, P>(
       >
         <NativeViewGestureHandler
           ref={nativeGestureRef}
-          enabled={enableContentPanningGesture}
+          enabled={scrollEnabled}
           shouldCancelWhenOutside={false}
         >
           <ScrollableComponent


### PR DESCRIPTION
…

Please provide enough information so that others can review your pull request:

## Motivation

This Pull Request enables users of this library to override the default behaviour of this library, where ScrollableComponent's NativeViewGestureHandler can only be enabled via `enableContentPanningGesture` setting. Even though the default behaviour is appropriate in 99% of the use cases of this library, sometimes a need may arise for this behaviour to be temporarily overridden
