### PR TITLE
fix: missing BottomSheetTextInput mock

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -109,6 +109,7 @@ module.exports = {
   BottomSheetSectionList: ReactNative.SectionList,
   BottomSheetFlatList: ReactNative.FlatList,
   BottomSheetVirtualizedList: ReactNative.VirtualizedList,
+  BottomSheetTextInput: ReactNative.TextInput,
 
   BottomSheetModalProvider,
   BottomSheetModal,


### PR DESCRIPTION
This PR adds the missing BottomSheetTextInput mock to the bottom-sheet/mock file. I don't know if is the best way to solve it but I tested on my app and worked. So let me know if you want me do it in other way.

## Motivation

I'm using Jest to test the app I'm working and to solve a previous error I added the `@gorhom/bottom-sheet/mock` to my jest mock file so now when I tried to use `BottomSheetTextInput` in one of my components my tests breaks because there is no `BottomSheetTextInput` been exported from the mock. 

So right now I added my self the BottomSheetTextInput to the mock:
```
jest.mock('@gorhom/bottom-sheet', () => ({
  __esModule: true,
  ...require('@gorhom/bottom-sheet/mock'),
  BottomSheetTextInput: require('react-native').TextInput,
}));
```

But would be nice to have it within the provided mock file
