### PR TITLE
fix: use absolute positioning for BottomSheetContainer in web (v5)

### DIFF
--- a/src/components/bottomSheetContainer/styles.web.ts
+++ b/src/components/bottomSheetContainer/styles.web.ts
@@ -2,8 +2,7 @@ import { StyleSheet } from 'react-native';
 
 export const styles = StyleSheet.create({
   container: {
-    // @ts-ignore
-    position: 'fixed',
+    position: 'absolute',
     left: 0,
     right: 0,
     bottom: 0,


### PR DESCRIPTION
## Motivation
With fixed positioning in web, the non-modal bottom sheet is not getting along with [bottom tab navigator](https://reactnavigation.org/docs/bottom-tab-navigator/) and is displayed under it. 
Using `absolute` allows BottomSheetContainer to be positioned relatively to containing elements instead of the viewport.

In native iOS/Android it is working as expected with bottom tab navigator.

Before
<img width="378" alt="image" src="https://github.com/gorhom/react-native-bottom-sheet/assets/1067120/4717531b-e9f6-40e6-9b06-2922e2f04278">

After 
<img width="380" alt="image" src="https://github.com/gorhom/react-native-bottom-sheet/assets/1067120/51c44e65-f919-4966-95b1-10c3652784e5">



