### PR TITLE
fix bottomsheet from appearing on rotation

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1301,6 +1301,10 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         let animationConfig;
         let animationSource = ANIMATION_SOURCE.SNAP_POINT_CHANGE;
 
+        if(animatedNextPositionIndex.value < 0 && animatedCurrentIndex.value < 0) {
+            return;
+        }
+
         /**
          * if the bottom sheet is closing and the container gets resized,
          * then we restart the closing animation to the new position.


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

using libraries:
Library | Version
-- | --
react-native-reanimated | 3.5.4
@gorhom/bottom-sheet | 4.5.1

rotation from landscape to portrait seems to bring up a dormant bottom-sheet as described here: https://github.com/gorhom/react-native-bottom-sheet/issues/516

i'm not sure if this is patching the issue or if its good enough to merge but thought i'd throw a PR up for your eyes and to help anybody else.


