### PR TITLE
feat: use underlying ScrollViewProps' `children` for BottomSheetScrollViewProps

### DIFF
--- a/src/components/bottomSheetScrollable/types.d.ts
+++ b/src/components/bottomSheetScrollable/types.d.ts
@@ -1,10 +1,4 @@
-import type {
-  DependencyList,
-  EffectCallback,
-  ReactNode,
-  Ref,
-  RefObject,
-} from 'react';
+import type { DependencyList, EffectCallback, Ref, RefObject } from 'react';
 import type {
   VirtualizedListProps,
   ScrollViewProps,
@@ -139,7 +133,6 @@ export type BottomSheetScrollViewProps = Omit<
 > &
   BottomSheetScrollableProps & {
     ref?: Ref<BottomSheetScrollViewMethods>;
-    children: ReactNode | ReactNode[];
   };
 
 export interface BottomSheetScrollViewMethods {


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

The normal ScrollViewProps interfaces (and extensions) take an optional `children` prop. BottomSheetScrollViewProps overrode this with a non-optional prop, causing TypeScript errors in certain use-cases.

This PR removes the override in order to use the underlying `children` prop in ScrollViewProps.

