### PR TITLE
fix: backdrop -> check if mounted before setting state

### DIFF
--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -69,16 +69,6 @@ const BottomSheetBackdropComponent = ({
   >(enableTouchThrough ? 'none' : 'auto');
   //#endregion
 
-  //#region effects
-  useEffect(() => {
-    // Without this we get "Warning: Can't perform a React state update on an unmounted component [...] in BottomSheetBackdrop"
-    isMounted.current = true;
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
-  //#endregion
-
   //#region callbacks
   const handleOnPress = useCallback(() => {
     onPress?.();
@@ -140,6 +130,16 @@ const BottomSheetBackdropComponent = ({
     [disappearsOnIndex]
   );
 
+  // addressing updating the state after unmounting.
+  // [link](https://github.com/gorhom/react-native-bottom-sheet/issues/1376)
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+  //#endregion
+
   const AnimatedView = (
     <Animated.View
       style={containerStyle}
@@ -158,7 +158,6 @@ const BottomSheetBackdropComponent = ({
       {children}
     </Animated.View>
   );
-  //#endregion
 
   return pressBehavior !== 'none' ? (
     <TapGestureHandler onGestureEvent={gestureHandler}>

--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -1,4 +1,11 @@
-import React, { memo, useCallback, useMemo, useState } from 'react';
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { ViewProps } from 'react-native';
 import Animated, {
   interpolate,
@@ -44,6 +51,7 @@ const BottomSheetBackdropComponent = ({
 }: BottomSheetDefaultBackdropProps) => {
   //#region hooks
   const { snapToIndex, close } = useBottomSheet();
+  const isMounted = useRef(false);
   //#endregion
 
   //#region defaults
@@ -61,6 +69,16 @@ const BottomSheetBackdropComponent = ({
   >(enableTouchThrough ? 'none' : 'auto');
   //#endregion
 
+  //#region effects
+  useEffect(() => {
+    // Without this we get "Warning: Can't perform a React state update on an unmounted component [...] in BottomSheetBackdrop"
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+  //#endregion
+
   //#region callbacks
   const handleOnPress = useCallback(() => {
     onPress?.();
@@ -75,7 +93,8 @@ const BottomSheetBackdropComponent = ({
   }, [snapToIndex, close, disappearsOnIndex, pressBehavior, onPress]);
   const handleContainerTouchability = useCallback(
     (shouldDisableTouchability: boolean) => {
-      setPointerEvents(shouldDisableTouchability ? 'none' : 'auto');
+      isMounted.current &&
+        setPointerEvents(shouldDisableTouchability ? 'none' : 'auto');
     },
     []
   );


### PR DESCRIPTION
closes https://github.com/gorhom/react-native-bottom-sheet/issues/1376 (has already been closed, although it hasn't been fixed yet )

## Motivation

When using the backdrop component you could get a `"Warning: Can't perform a React state update on an unmounted component [...] in BottomSheetBackdrop"` error.

This PR adds a check if the component is mounted before setting the local state to fix that issue.

