### PR TITLE
fix: allow initial snapPoint index greater than 0

### DIFF
--- a/src/hooks/useNormalizedSnapPoints.ts
+++ b/src/hooks/useNormalizedSnapPoints.ts
@@ -27,18 +27,18 @@ export const useNormalizedSnapPoints = (
   maxDynamicContentSize: BottomSheetProps['maxDynamicContentSize']
 ) => {
   const normalizedSnapPoints = useDerivedValue(() => {
-    // early exit, if container layout is not ready
-    const isContainerLayoutReady =
-      containerHeight.value !== INITIAL_CONTAINER_HEIGHT;
-    if (!isContainerLayoutReady) {
-      return [INITIAL_SNAP_POINT];
-    }
-
     const _snapPoints = snapPoints
       ? 'value' in snapPoints
         ? snapPoints.value
         : snapPoints
       : [];
+
+    // early exit, if container layout is not ready
+    const isContainerLayoutReady =
+      containerHeight.value !== INITIAL_CONTAINER_HEIGHT;
+    if (!isContainerLayoutReady) {
+      return new Array(_snapPoints.length || 1).fill(INITIAL_SNAP_POINT);
+    }
 
     let _normalizedSnapPoints = _snapPoints.map(snapPoint =>
       normalizeSnapPoint(snapPoint, containerHeight.value)


### PR DESCRIPTION
## Motivation

This is to fix bug #1689. 
Since version 4.5.0 there has been logic that if the container layout is not ready, the returned snapPoints are an array with just a single item `[-999]`. As a result, on initial load, before the container layout is ready, if you have passed in the index prop to the `BottomSheet` with a value greater than 0 (e.g. if you're passing in more than one snap point value, and have passed in  `index={1}` as you want the drawer to start open), it immediately errors as the index is out of range of the initial snapPoint array of `[-999]`. 

This PR reverts the initial load logic to how it was before version 4.5.0, where if the container layout is not yet ready, it returns instead an array filled with `-999` that matches the length of the passed in snapPoint array. 

