### PR TITLE
Add BottomSheetTextInput to the mock

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -105,6 +105,7 @@ const useBottomSheetDynamicSnapPoints = () => ({
 
 module.exports = {
   BottomSheetView: BottomSheetComponent,
+  BottomSheetTextInput: ReactNative.TextInput,
   BottomSheetScrollView: ReactNative.ScrollView,
   BottomSheetSectionList: ReactNative.SectionList,
   BottomSheetFlatList: ReactNative.FlatList,


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:
## Tests failing due to using `BottomSheetTextInput` in the components

I noticed an error in the unit tests when using `BottomSheetTextInput` component in the components. because the `BottomSheetTextInput` is not exposed in the mock object.
The error is 
```
TaskQueue: Error with task : Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

    Check the render method of `ForwardRef`.
```

## Motivation

So I added the `BottomSheetTextInput` in the mock object to resolve the unit tests errors

