### PR TITLE
Add missing mock of Touchables

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -110,6 +110,10 @@ module.exports = {
   BottomSheetFlatList: ReactNative.FlatList,
   BottomSheetVirtualizedList: ReactNative.VirtualizedList,
 
+  TouchableOpacity: ReactNative.TouchableOpacity,
+  TouchableHighlight: ReactNative.TouchableHighlight,
+  TouchableWithoutFeedback: ReactNative.TouchableWithoutFeedback,
+
   BottomSheetModalProvider,
   BottomSheetModal,
   BottomSheetBackdrop,


### PR DESCRIPTION
## Motivation

Similarly to #1698 from @ghorbani-m. This PR adds missing mocks for Touchables. Without it when they're used in tested components, user will get this error:

`Warning: React.jsx: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.`