### PR TITLE
Fix: example script path configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,23 +12,11 @@ yarn bootstrap
 
 While developing, you can run the [example app](/example/) to test your changes.
 
-To start the packager:
-
-```sh
-yarn example start
-```
-
-To run the example app on Android:
-
-```sh
-yarn example android
-```
-
-To run the example app on iOS:
-
-```sh
-yarn example android
-```
+| Description |[Bare](https://reactnative.dev/docs/environment-setup?guide=native) | [Expo](https://reactnative.dev/docs/environment-setup?guide=quickstart) |
+| --- | --- |--- |
+|**Start Packager** | `yarn example:bare start` | `yarn example:expo start`|
+|**Run on Android** | `yarn example:bare android` | `yarn example:expo android`|
+|**Run on iOS** | `yarn example:bare ios` | `yarn example:expo ios`|
 
 Make sure your code passes TypeScript and ESLint. Run the following to verify:
 

--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "delete-debug-view": "rm -r ./lib/commonjs/components/bottomSheetDebugView && rm -r ./lib/module/components/bottomSheetDebugView && rm -r ./lib/typescript/components/bottomSheetDebugView",
     "delete-dts.js": "find ./lib/commonjs -name '*.d.js*' -delete && find ./lib/module -name '*.d.js*' -delete",
     "release": "rm -rf lib && yarn build && release-it",
-    "example": "yarn --cwd example",
-    "bootstrap": "yarn install && yarn example"
+    "example:bare": "yarn --cwd ./example/bare",
+    "example:expo": "yarn --cwd ./example/expo",
+    "bootstrap": "yarn install && yarn example:bare && yarn example:expo"
   },
   "dependencies": {
     "@gorhom/portal": "1.0.14",


### PR DESCRIPTION
This pull request addresses the issue where the script path in the ```package.json``` file was incorrect, preventing the successful launch of the yarn example. The script path has been updated to resolve this problem.

## Motivation

This is my first try in open source contribution

