### PR TITLE
feature: add to get animated info on bottom sheet methods

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1105,6 +1105,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     );
 
     useImperativeHandle(ref, () => ({
+      animatedIndex,
+      animatedPosition,
       snapToIndex: handleSnapToIndex,
       snapToPosition: handleSnapToPosition,
       expand: handleExpand,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -76,6 +76,16 @@ export interface BottomSheetMethods {
    * @see {WithTimingConfig}
    */
   forceClose: (animationConfigs?: WithSpringConfig | WithTimingConfig) => void;
+  /**
+   * Current sheet position index.
+   * @type SharedValue<number>
+   */
+  animatedIndex: SharedValue<number>;
+  /**
+   * Current sheet position.
+   * @type SharedValue<number>
+   */
+  animatedPosition: SharedValue<number>;
 }
 export interface BottomSheetModalMethods extends BottomSheetMethods {
   /**


### PR DESCRIPTION
## Motivation

The changes were made to provide more control and flexibility over the BottomSheet component. By exposing animatedIndex and animatedPosition, users of the BottomSheet component can now access and manipulate the current sheet position index and position directly. This can be useful for creating more complex interactions or animations with the BottomSheet component.


## Example

https://github.com/gorhom/react-native-bottom-sheet/assets/2025813/2919bdb6-acdc-41d6-8b29-3f546e547f8a

