### PR TITLE
fix: bottom sheet not appearing for users that have reduced motion turned on

### DIFF
--- a/src/utilities/animate.ts
+++ b/src/utilities/animate.ts
@@ -4,6 +4,7 @@ import {
   withTiming,
   withSpring,
   AnimationCallback,
+  ReduceMotion,
 } from 'react-native-reanimated';
 import { ANIMATION_CONFIGS, ANIMATION_METHOD } from '../constants';
 
@@ -25,6 +26,11 @@ export const animate = ({
   if (!configs) {
     configs = ANIMATION_CONFIGS;
   }
+
+  // Users might have an accessibililty setting to reduce motion turned on.
+  // This prevents the animation from running when presenting the sheet, which results in
+  // the bottom sheet not even appearing so we need to override it to ensure the animation runs.
+  configs.reduceMotion = ReduceMotion.Never;
 
   // detect animation type
   const type =


### PR DESCRIPTION
Hello @gorhom 

## Motivation

Thank you for this great library! Here's a super simple PR that fixes #1560 and #1674. In recent versions of Android and in iOS, there's a "Reduce motion" feature which decreases the overall number of animations alongside the OS and slightly alters them as well. With Reanimated's default settings, this now means that some animations will fail to run, including the very critical one which this library uses to present the sheet. Thankfully, Reanimated exposes an ability to override this config via a `reduceMotion` option on the animation configs. This PR hardcodes the `ReduceMotion.Never` option to the animate function. I don't think it would ever be in the interest of the user to override this, otherwise the sheet could fail to be presented, so that's the reason why I hardcoded it. I also pointed this to the `v5` branch since `v5` has reanimated 3.x and it seems this API is available only since 3.x, and master is still on `2.x`. I've verified that this works on the example app and that sheets are presented with Reduce Motion turned on a physical iPhone 14 Pro running 17.3, whereas it was broken when `ReduceMotion.Never` was NOT used.

