### PR TITLE
fix: dismiss keyboard if it remains open in collapsed mode

### DIFF
--- a/src/hooks/useGestureEventsHandlersDefault.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.tsx
@@ -334,7 +334,14 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
           if (destinationPoint === animatedPosition.value) {
             return;
           }
-
+          /**
+           * Handles the scenario where the bottom sheet is in the collapsed mode, 
+           * but the keyboard remains open. This occurs when the user drags from a <View> 
+           * and releases the finger while it's positioned over the keyboard.
+           */
+          if(destinationPoint === highestSnapPoint && animatedKeyboardState.value === KEYBOARD_STATE.SHOWN ){
+            runOnJS(dismissKeyboard)();
+          }
           const wasGestureHandledByScrollView =
             source === GESTURE_SOURCE.SCROLLABLE &&
             animatedScrollableContentOffsetY.value > 0;


### PR DESCRIPTION
## Motivation

Currently, there's an issue where the keyboard remains visible even when the bottom sheet is collapsed in certain scenarios.

This problem arises when the user drags the bottom sheet from the <FooterWrapper/> or the top of the modal and releases their finger while it's positioned over the keyboa

```
 return (
    <>
      <BottomSheetModal
        onDismiss={() => {
        }}
        onChange={() => {}}
        ref={someref}
        backgroundComponent={EmptyView}
        snapPoints={snapPoints}
        style={{
        }}
        backdropComponent={renderBackdrop}
        handleComponent={EmptyView}>
        <View
          style={[
            styles.container
          ]}>
          <FlexRow
            style={styles.header}
            alignItems={'center'}
            justifyContent={'space-between'}>
            <View style={styles.right}>
                  <Typography variant={'h21'} color={'error'}>
                         some text
                  </Typography>
                </TouchableOpacity>
              )}
            </View>
            <View style={{ marginRight: 20 }}>
              <Typography variant={'h26'}>some text </Typography>
            </View>
            <TouchableOpacity
              onPress={() => {
                }
              }}
              style={styles.editButton}
              hitSlop={...}>
              <Typography color={'primary'} variant={'h21'}>
                {some text}
              </Typography>
            </TouchableOpacity>
          </FlexRow>
          <View style={styles.footerWrapper}>
            <FooterWrapper
              {...props}
            />
          </View>
        </View>
      </BottomSheetModal>

  );
````
