### PR TITLE
Use function instead of component for BottomSheetModal children

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -390,7 +390,7 @@ const BottomSheetModalComponent = forwardRef<
           onChange={handleBottomSheetOnChange}
           onClose={handleBottomSheetOnClose}
           children={
-            typeof Content === 'function' ? <Content data={data} /> : Content
+            typeof Content === 'function' ? Content({ data }) : Content
           }
           $modal={true}
         />


### PR DESCRIPTION
## Motivation

As `data` is an object, rendering `<Content data={data} />` creates a lot of unwanted re-render. Changing it to a function solves this issue.
