### PR TITLE
fix: fix bug on default animate config setting

### DIFF
--- a/src/utilities/animate.ts
+++ b/src/utilities/animate.ts
@@ -17,11 +17,15 @@ interface AnimateParams {
 
 export const animate = ({
   point,
-  configs = ANIMATION_CONFIGS,
+  configs,
   velocity = 0,
   onComplete,
 }: AnimateParams) => {
   'worklet';
+
+  if (!configs) {
+    configs = ANIMATION_CONFIGS;
+  }
 
   // Users might have an accessibility setting to reduce motion turned on.
   // This prevents the animation from running when presenting the sheet, which results in


### PR DESCRIPTION
## Motivation

I'm testing bottom sheet v5 alpha.8 version. 
Then, I got error below. 

```
16:48:59 ERROR : ReanimatedError: Property 'ANIMATION_CONFIGS' doesn't exist, js engine: reanimated
```

<img width="402" alt="Screenshot 2024-02-27 at 4 49 04 PM" src="https://github.com/gorhom/react-native-bottom-sheet/assets/64301935/29942109-142c-48ff-8f59-84dc9a741ced">

I fixed to set default config under 'worklet', then it works fine. 

Thanks for great library! 🙌

