### PR TITLE
Fix: allow screen readers to detect modal content

### DIFF
--- a/example/bare/android/build.gradle
+++ b/example/bare/android/build.gradle
@@ -3,10 +3,10 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 buildscript {
     ext {
-        buildToolsVersion = "31.0.0"
+        buildToolsVersion = "32.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 32
+        targetSdkVersion = 32
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
@@ -48,6 +48,11 @@ allprojects {
             }
         }
         google()
+        jcenter() {
+            content {
+                includeModule("com.eightbitlab", "blurview")
+            }
+        }
         maven { url 'https://www.jitpack.io' }
     }
 }

--- a/src/components/bottomSheetBackground/BottomSheetBackground.tsx
+++ b/src/components/bottomSheetBackground/BottomSheetBackground.tsx
@@ -7,13 +7,7 @@ const BottomSheetBackgroundComponent = ({
   pointerEvents,
   style,
 }: BottomSheetBackgroundProps) => (
-  <View
-    pointerEvents={pointerEvents}
-    accessible={true}
-    accessibilityRole="adjustable"
-    accessibilityLabel="Bottom Sheet"
-    style={[styles.container, style]}
-  />
+  <View pointerEvents={pointerEvents} style={[styles.container, style]} />
 );
 
 const BottomSheetBackground = memo(BottomSheetBackgroundComponent);

--- a/src/components/bottomSheetBackgroundContainer/BottomSheetBackgroundContainer.tsx
+++ b/src/components/bottomSheetBackgroundContainer/BottomSheetBackgroundContainer.tsx
@@ -20,7 +20,7 @@ const BottomSheetBackgroundContainerComponent = ({
 
   return _providedBackgroundComponent === null ? null : (
     <BackgroundComponent
-      pointerEvents="none"
+      pointerEvents="box-none"
       animatedIndex={animatedIndex}
       animatedPosition={animatedPosition}
       style={backgroundStyle}

--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -52,6 +52,10 @@ const BottomSheetModalComponent = forwardRef<
 
     // components
     children: Content,
+
+    // Override default accessibility prop to ensure their content can be read by Voice Over (iOS screen reader)
+    accessible = null,
+
     ...bottomSheetProps
   } = props;
 
@@ -379,6 +383,7 @@ const BottomSheetModalComponent = forwardRef<
       <ContainerComponent key={key}>
         <BottomSheet
           {...bottomSheetProps}
+          accessible={accessible}
           ref={bottomSheetRef}
           key={key}
           index={index}


### PR DESCRIPTION
Hello @gorhom, thank you for this nice package :)

Here is a small contribution based on accessibility findings using TalkBack on Android and Voice Over on iOS.
If you are interested I could also port it to version 5

## Motivation

In the project I work on, accessibility support is a requirement. I noticed a few issues when integrating `<BottomSheetModal />` (we currently do not use `<BottomSheet />`):

1. Children cannot be read by Voice Over (iOS), only the modal itself is interpreted as a single "adjustable" view (my guess here is that elements with "accessibleRole: 'adjustable'" are not meant to have children? I could be wrong, this is just an assumption)
2. Text elements cannot be interpreted by Talk Back (Android) when using the default background, due to its accessibility props. This could easily be workaround by providing a custom background but I figured I could also propose this fix here.
3. I also face the issues described in #1641, but I did not manage to understand how to fix those myself unfortunately. I tried implementing some state in BottomSheetModalProvider (as initially proposed in #687), but since modals can be closed/dismissed in different ways, I could not implement a reliable state determining whether or not a modal is currently being presented (and adjust `importantForAccessibility` props based on that).

I recorded videos to illustrate what this PR fixes:

1. TalkBack

https://github.com/gorhom/react-native-bottom-sheet/assets/1577155/a7fa04c4-2e02-429a-a0f6-6e51d5644cd2
https://github.com/gorhom/react-native-bottom-sheet/assets/1577155/106c7c0c-c625-450a-ba29-3c34a3eb2927

2. Voice Over (unavailable in iOS simulator, but I used Accessibility Inspector instead)

https://github.com/gorhom/react-native-bottom-sheet/assets/1577155/dd0f8f89-71ec-49be-8d0a-09dd84943d6e
https://github.com/gorhom/react-native-bottom-sheet/assets/1577155/2d5ca920-d1e9-4afc-9b67-38122e016844