### PR TITLE
refactor: refactored the snap points reactions and improve snapping sequencing

### DIFF
--- a/example/src/screens/advanced/KeyboardHandlingExample.tsx
+++ b/example/src/screens/advanced/KeyboardHandlingExample.tsx
@@ -73,6 +73,7 @@ const KeyboardHandlingExample = () => {
       <BottomSheet
         ref={bottomSheetRef}
         snapPoints={snapPoints}
+        enableDynamicSizing={false}
         keyboardBehavior={keyboardBehavior}
         keyboardBlurBehavior={keyboardBlurBehavior}
         handleComponent={SearchHandle}

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1468,9 +1468,13 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       () => animatedSnapPoints.value,
       (result, previous) => {
         /**
-         * if values did not change, then we early exit the method.
+         * if values did not change, and did handle on mount animation
+         * then we early exit the method.
          */
-        if (JSON.stringify(result) === JSON.stringify(previous)) {
+        if (
+          JSON.stringify(result) === JSON.stringify(previous) &&
+          isAnimatedOnMount.value
+        ) {
           return;
         }
 

--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -317,6 +317,7 @@ const BottomSheetModalComponent = forwardRef<
       print({
         component: BottomSheetModal.name,
         method: handleBottomSheetOnChange.name,
+        category: 'callback',
         params: {
           minimized: minimized.current,
           forcedDismissed: forcedDismissed.current,
@@ -335,6 +336,7 @@ const BottomSheetModalComponent = forwardRef<
       print({
         component: BottomSheetModal.name,
         method: handleBottomSheetOnClose.name,
+        category: 'callback',
         params: {
           minimized: minimized.current,
           forcedDismissed: forcedDismissed.current,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -18,6 +18,6 @@ export { useGestureEventsHandlersDefault } from './useGestureEventsHandlersDefau
 export { useKeyboard } from './useKeyboard';
 export { useStableCallback } from './useStableCallback';
 export { usePropsValidator } from './usePropsValidator';
-export { useNormalizedSnapPoints } from './useNormalizedSnapPoints';
+export { useAnimatedSnapPoints } from './useAnimatedSnapPoints';
 export { useReactiveSharedValue } from './useReactiveSharedValue';
 export { useBottomSheetGestureHandlers } from './useBottomSheetGestureHandlers';

--- a/src/hooks/useAnimatedSnapPoints.ts
+++ b/src/hooks/useAnimatedSnapPoints.ts
@@ -22,14 +22,14 @@ import {
  * @param maxDynamicContentSize
  * @returns {Animated.SharedValue<number[]>}
  */
-export const useNormalizedSnapPoints = (
+export const useAnimatedSnapPoints = (
   snapPoints: BottomSheetProps['snapPoints'],
   containerHeight: SharedValue<number>,
   contentHeight: SharedValue<number>,
   handleHeight: SharedValue<number>,
   enableDynamicSizing: BottomSheetProps['enableDynamicSizing'],
   maxDynamicContentSize: BottomSheetProps['maxDynamicContentSize']
-): [SharedValue<number[]>, SharedValue<number>] => {
+): [SharedValue<number[]>, SharedValue<number>, SharedValue<boolean>] => {
   const dynamicSnapPointIndex = useSharedValue<number>(-1);
   const normalizedSnapPoints = useDerivedValue(() => {
     // early exit, if container layout is not ready
@@ -100,5 +100,34 @@ export const useNormalizedSnapPoints = (
     maxDynamicContentSize,
     dynamicSnapPointIndex,
   ]);
-  return [normalizedSnapPoints, dynamicSnapPointIndex];
+
+  const hasDynamicSnapPoint = useDerivedValue(() => {
+    /**
+     * if dynamic sizing is enabled, then we return true.
+     */
+    if (enableDynamicSizing) {
+      return true;
+    }
+
+    // extract snap points from provided props
+    const _snapPoints = snapPoints
+      ? 'value' in snapPoints
+        ? snapPoints.value
+        : snapPoints
+      : [];
+
+    /**
+     * if any of the snap points provided is a string, then we return true.
+     */
+    if (
+      _snapPoints.length &&
+      _snapPoints.find(snapPoint => typeof snapPoint === 'string')
+    ) {
+      return true;
+    }
+
+    return false;
+  });
+
+  return [normalizedSnapPoints, dynamicSnapPointIndex, hasDynamicSnapPoint];
 };


### PR DESCRIPTION
## Motivation

This PR introduces a fully rewritten snap points reactions handler which stabilised the snapping sequencing when multiple events trigger the snap mechanism.

The new handler insures that snap points changes does not block keyboard or any other triggers but to respect them and re-evaluate the bottom sheet position accordingly.

#### Use cases

This PR should fix

- on mount animation while parent container is resizing
- on mount animation with text input is auto focus 
- resizing snap points
- resizing content
- other more

##### Preview

https://github.com/gorhom/react-native-bottom-sheet/assets/4061838/398415f5-20d0-4f74-bdd6-cf61916e8c94

