### PR TITLE
Fix BottomSheet closing instantly when snapPoints change

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1361,7 +1361,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
             animatedNextPositionIndex.value !== -1
               ? snapPoints[animatedNextPositionIndex.value]
               : animatedNextPosition.value;
-        } else if (animatedAnimationState.value === ANIMATION_STATE.STOPPED) {
+        } else if (animatedAnimationState.value === ANIMATION_STATE.STOPPED && animatedIndex.value % 1 === 0) {
           nextPosition = snapPoints[animatedIndex.value]
         } else if (animatedCurrentIndex.value === -1) {
           nextPosition = animatedClosedPosition.value;

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -665,6 +665,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           },
         });
 
+        animatedCurrentIndex.value = animatedNextPosition.value;
         animatedAnimationSource.value = ANIMATION_SOURCE.NONE;
         animatedAnimationState.value = ANIMATION_STATE.STOPPED;
         animatedNextPosition.value = INITIAL_VALUE;

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -665,7 +665,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           },
         });
 
-        animatedCurrentIndex.value = animatedNextPosition.value;
+        animatedCurrentIndex.value = animatedNextPositionIndex.value;
         animatedAnimationSource.value = ANIMATION_SOURCE.NONE;
         animatedAnimationState.value = ANIMATION_STATE.STOPPED;
         animatedNextPosition.value = INITIAL_VALUE;

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -665,7 +665,6 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           },
         });
 
-        animatedCurrentIndex.value = animatedNextPositionIndex.value;
         animatedAnimationSource.value = ANIMATION_SOURCE.NONE;
         animatedAnimationState.value = ANIMATION_STATE.STOPPED;
         animatedNextPosition.value = INITIAL_VALUE;
@@ -1362,6 +1361,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
             animatedNextPositionIndex.value !== -1
               ? snapPoints[animatedNextPositionIndex.value]
               : animatedNextPosition.value;
+        } else if (animatedAnimationState.value === ANIMATION_STATE.STOPPED) {
+          nextPosition = snapPoints[animatedIndex.value]
         } else if (animatedCurrentIndex.value === -1) {
           nextPosition = animatedClosedPosition.value;
         } else if (isInTemporaryPosition.value) {


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

Probably related to https://github.com/gorhom/react-native-bottom-sheet/issues/1053

When snapPoints of a bottom sheet change while its animating, it may close it in some situations.
After some investigation, I think the reason for that is the animatedReaction on snapPoints/containerHeight that closes the bottom sheet under these conditions : `animatedCurrentIndex.value === -1` 

The problem being in some cases, when animation complete, the snapPoints change reaction seems to be called right after the completion callback, before any reaction on the animatedPosition. Since the the animatedPosition reaction is the one setting the animatedCurrentIndex value, this old value is used and causes the closing of the bottom sheet.

~~This fix is a simple line on the completion callback, setting the animatedCurrentIndex value to its goal value.~~
**The previous fix caused an issue where the onChange callback would not fire anymore.**

A better fix is to handle the case were the animation is STOPPPED in the snapPoints change listener, and set the new position using the actual animatedIndex value.