### PR TITLE
chore: remove unused ts-expected-error

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,4 @@
 import { Dimensions, Platform } from 'react-native';
-// @ts-expect-error Module '"react-native-reanimated"' has no exported member 'ReduceMotion'
 import Animated, { Easing, ReduceMotion } from 'react-native-reanimated';
 
 const { height: WINDOW_HEIGHT, width: WINDOW_WIDTH } = Dimensions.get('window');


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

It seems like @ts-expect-error isn't needed anymore with the last update. My TS check complaining on this line "Unused '@ts-expect-error' directive"

