### PR TITLE
chore: only mark issues that dont follow the template as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,3 +28,4 @@ jobs:
         exempt-assignees: 'gorhom'
         exempt-issue-labels: 'sponsor'
         exempt-pr-labels: 'sponsor'
+        any-of-labels: 'not-following-issue-template'


### PR DESCRIPTION
## Motivation

Currently, all the issues, regardless if they follow the template or not, are marked as stale after a period of time. This PR adds the [any-of-labels](https://github.com/actions/stale?tab=readme-ov-file#any-of-labels) option to the stale bot so only the issues that aren't following the issue template are marked as stale.

