### PR TITLE
Docs: Update URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,22 @@ A performant interactive bottom sheet with fully configurable options 🚀
 
 ## Features
 
-- Modal presentation view, [Bottom Sheet Modal](https://ui.gorhom.dev/components/bottom-sheet/modal).
+- Modal presentation view, [Bottom Sheet Modal](https://gorhom.dev/react-native-bottom-sheet/modal).
 - Smooth gesture interactions & snapping animations.
-- Seamless [keyboard handling](https://ui.gorhom.dev/components/bottom-sheet/keyboard-handling).
+- Seamless [keyboard handling](https://gorhom.dev/react-native-bottom-sheet/keyboard-handling).
 - Support React Native Web 🔥
-- Support [pull to refresh](https://ui.gorhom.dev/components/bottom-sheet/pull-to-refresh) for scrollables.
-- Support [FlatList](https://ui.gorhom.dev/components/bottom-sheet/components/bottomsheetflatlist), [SectionList](https://ui.gorhom.dev/components/bottom-sheet/components/bottomsheetsectionlist), [ScrollView](https://ui.gorhom.dev/components/bottom-sheet/components/bottomsheetscrollview) & [View](https://ui.gorhom.dev/components/bottom-sheet/components/bottomsheetview) scrolling interactions.
-- Support [React Navigation integration](https://ui.gorhom.dev/components/bottom-sheet/react-navigation-integration).
+- Support [pull to refresh](https://gorhom.dev/react-native-bottom-sheet/pull-to-refresh) for scrollables.
+- Support [FlatList](https://gorhom.dev/react-native-bottom-sheet/components/bottomsheetflatlist), [SectionList](https://gorhom.dev/react-native-bottom-sheet/components/bottomsheetsectionlist), [ScrollView](https://gorhom.dev/react-native-bottom-sheet/components/bottomsheetscrollview) & [View](https://gorhom.dev/react-native-bottom-sheet/components/bottomsheetview) scrolling interactions.
+- Support [React Navigation integration](https://gorhom.dev/react-native-bottom-sheet/react-navigation-integration).
 - Compatible with `Reanimated` v1-3.
 - Compatible with `Expo`.
 - Accessibility support.
 - Written in `TypeScript`.
-- [Read more](https://ui.gorhom.dev/components/bottom-sheet).
+- [Read more](https://gorhom.dev/react-native-bottom-sheet).
 
 ## Getting Started
 
-Check out [the documentation website](https://ui.gorhom.dev/components/bottom-sheet).
+Check out [the documentation website](https://gorhom.dev/react-native-bottom-sheet).
 
 ## Versioning
 


### PR DESCRIPTION
The URLs inside the README.md were not updated.

## Motivation

I have updated the URLs leading to the documentation in the README.md to the current ones.

For example, https://ui.gorhom.dev/components/bottom-sheet was not redirecting correctly.
