### PR TITLE
Update link to `NavigatorExample` in docs

### DIFF
--- a/website/docs/guides/react-navigation.md
+++ b/website/docs/guides/react-navigation.md
@@ -13,4 +13,4 @@ However, there are some tricks has to be follow to enable both libraries to work
 
 - You need to override `safeAreaInsets`, by default `React Navigation` add the safe area insets to all its navigators, but since your navigator will properly won't cover full screen, you will need to override it and set it to `0`.
 
-For more details regarding the implementation, please have a look at the [Navigator Example](https://github.com/gorhom/react-native-bottom-sheet/blob/master/example/bare/src/screens/integrations/NavigatorExample.tsx).
+For more details regarding the implementation, please have a look at the [Navigator Example](https://github.com/gorhom/react-native-bottom-sheet/blob/master/example/src/screens/integrations/NativeScreensExample.tsx).

--- a/website/docs/guides/react-navigation.md
+++ b/website/docs/guides/react-navigation.md
@@ -13,4 +13,5 @@ However, there are some tricks has to be follow to enable both libraries to work
 
 - You need to override `safeAreaInsets`, by default `React Navigation` add the safe area insets to all its navigators, but since your navigator will properly won't cover full screen, you will need to override it and set it to `0`.
 
-For more details regarding the implementation, please have a look at the [Navigator Example](https://github.com/gorhom/react-native-bottom-sheet/blob/master/example/src/screens/integrations/NativeScreensExample.tsx).
+For more details regarding the implementation, please have a look at the [Navigator Example](https://github.com/gorhom/react-native-bottom-sheet/blob/master/example/src/screens/integrations/navigation/NavigatorExample.tsx)
+).


### PR DESCRIPTION
## Motivation

The current link is to a 404. Updating the link to the current example 

### Broken link 
[Navigator Example](https://github.com/gorhom/react-native-bottom-sheet/blob/master/example/bare/src/screens/integrations/NavigatorExample.tsx)

### Updated link 
[Navigator Example](https://github.com/gorhom/react-native-bottom-sheet/blob/master/example/src/screens/integrations/navigation/NavigatorExample.tsx)