### PR TITLE
fix: Default animatedNextPositionIndex to INITIAL_VALUE

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -237,7 +237,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     );
     const animatedPosition = useSharedValue(INITIAL_POSITION);
     const animatedNextPosition = useSharedValue(INITIAL_VALUE);
-    const animatedNextPositionIndex = useSharedValue(0);
+    const animatedNextPositionIndex = useSharedValue(INITIAL_VALUE);
 
     // conditional
     const isAnimatedOnMount = useSharedValue(false);


### PR DESCRIPTION
## Motivation

This fix is very similar to #1035 and #1043

BottomSheet will sometimes not animate/expand because of [this logic](https://github.com/gorhom/react-native-bottom-sheet/blob/b6e405b66dcdd4607b151c3a240250d0d2c12571/src/components/bottomSheet/BottomSheet.tsx#L1238). This can happen when you have a single `snapPoint`, or if you use `enableDynamicSizing`. 

## Issue

`animatedNextPositionIndex` starts at 0, which is the same as `snapPoints.length -1`, causing the animation to be aborted.

Starting values:
https://github.com/gorhom/react-native-bottom-sheet/blob/b6e405b66dcdd4607b151c3a240250d0d2c12571/src/components/bottomSheet/BottomSheet.tsx#L239-L240

After a successful animation, it is reset correctly to the right value:

Reset values:
https://github.com/gorhom/react-native-bottom-sheet/blob/b6e405b66dcdd4607b151c3a240250d0d2c12571/src/components/bottomSheet/BottomSheet.tsx#L647-L648

It should always start at `INITIAL_VALUE` (-Infinity) like `animatedNextPosition`.

## Reproducing

Note: this isn't always reproducible for me. I have two identical BottomSheets, and only one of them is broken. Something in the working one is resetting the `animatedNextPositionIndex.value` to `-Infinity` before the animation runs, but I'm struggling to debug where that's happening.