### PR TITLE
fix: auto-close action

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   autoclose:
     runs-on: ubuntu-latest
-    if: contains(github.event.issue.body, 'snack.expo.dev') != 'true'
+    if: {{ !contains(github.event.issue.body, 'snack.expo.dev') }}
     permissions:
       issues: write
     steps:


### PR DESCRIPTION
Not sure how to test this but I think the check in auto close is always returning false and so always closing issues. Probably because its `true` not `'true'`

saw a similar example here
https://github.com/orgs/community/discussions/26712#discussioncomment-3253013

## Motivation

All issues being created right now are automatically closed even when following the template correctly

