### PR TITLE
fix: add children to BottomSheetModal containerComponent type

### DIFF
--- a/src/components/bottomSheetModal/types.d.ts
+++ b/src/components/bottomSheetModal/types.d.ts
@@ -43,7 +43,7 @@ export interface BottomSheetModalProps
    * @type React.ComponentType
    * @default undefined
    */
-  containerComponent?: React.FC;
+  containerComponent?: React.ComponentType<React.PropsWithChildren>;
 
   // callbacks
   /**


### PR DESCRIPTION
## Motivation

`children` as default prop of `React.FC` was removed in React 18 so it needs to be explicitly defined. Otherwise this code throws error:

```tsx
        <BottomSheetModal
             {...otherProps}
            // this will throw TS error
            containerComponent={({ children }) => <WindowOverlay>{children}</WindowOverlay>}
        >
```

