### PR TITLE
feat: respect users' preferredd color scheme

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -80,7 +80,7 @@ const config: Config = {
     image: 'img/preview.gif',
 
     colorMode: {
-      defaultMode: 'light',
+      defaultMode: 'dark',
       disableSwitch: false,
       respectPrefersColorScheme: true,
     },

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -79,6 +79,12 @@ const config: Config = {
     // Replace with your project's social card
     image: 'img/preview.gif',
 
+    colorMode: {
+      defaultMode: 'light',
+      disableSwitch: false,
+      respectPrefersColorScheme: true,
+    },
+
     navbar: {
       title: 'React Native Bottom Sheet',
       logo: {


### PR DESCRIPTION
These are the changes to the [Docusaurus theme config](https://docusaurus.io/docs/api/themes/configuration#color-mode---dark-mode) so that it prefers the user's system color scheme instead of just defaulting to the light one.

I left the light mode as the default for cases when system preferences are unavailable, to be consistent in this regard with the official [react.dev](https://react.dev/) documentation ([see this line of code](https://github.com/reactjs/react.dev/blob/main/src/styles/index.css#L384)) and the official React Native documentation (https://github.com/facebook/react-native-website/pull/4262).