### PR TITLE
fix: cannot add new property 'reduceMotion'

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -22,6 +22,7 @@ import Animated, {
   useWorkletCallback,
   type WithSpringConfig,
   type WithTimingConfig,
+  ReduceMotion,
 } from 'react-native-reanimated';
 // import BottomSheetDebugView from '../bottomSheetDebugView';
 import {
@@ -94,8 +95,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     //#region extract props
     const {
       // animations configurations
-      animationConfigs: _providedAnimationConfigs,
-
+      animationConfigs,
       // configurations
       index: _providedIndex = 0,
       snapPoints: _providedSnapPoints,
@@ -177,6 +177,18 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         bottomInset,
       });
     }
+    //#endregion
+
+    //#region animations configurations
+    const _providedAnimationConfigs = useMemo(() => {
+      if (!animationConfigs) {
+        return undefined;
+      }
+     
+      animationConfigs.reduceMotion = ReduceMotion.Never;
+
+      return animationConfigs;
+    }, [animationConfigs]);
     //#endregion
 
     //#region layout variables
@@ -708,6 +720,10 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          * fire `onAnimate` callback
          */
         runOnJS(handleOnAnimate)(animatedNextPositionIndex.value);
+
+        if (configs !== undefined) {
+          configs.reduceMotion = ReduceMotion.Never;
+        }
 
         /**
          * start animation

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import { Dimensions, Platform } from 'react-native';
 import type Animated from 'react-native-reanimated';
-import { Easing } from 'react-native-reanimated';
+import { Easing, ReduceMotion } from 'react-native-reanimated';
 
 const { height: WINDOW_HEIGHT, width: WINDOW_WIDTH } = Dimensions.get('window');
 const { height: SCREEN_HEIGHT, width: SCREEN_WIDTH } = Dimensions.get('screen');
@@ -78,11 +78,13 @@ const ANIMATION_CONFIGS_IOS = {
   overshootClamping: true,
   restDisplacementThreshold: 10,
   restSpeedThreshold: 10,
+  reduceMotion: ReduceMotion.Never,
 };
 
 const ANIMATION_CONFIGS_ANDROID = {
   duration: ANIMATION_DURATION,
   easing: ANIMATION_EASING,
+  reduceMotion: ReduceMotion.Never,
 };
 
 const ANIMATION_CONFIGS =

--- a/src/utilities/animate.ts
+++ b/src/utilities/animate.ts
@@ -1,6 +1,5 @@
 import {
   type AnimationCallback,
-  ReduceMotion,
   type WithSpringConfig,
   type WithTimingConfig,
   withSpring,
@@ -26,11 +25,6 @@ export const animate = ({
   if (!configs) {
     configs = ANIMATION_CONFIGS;
   }
-
-  // Users might have an accessibility setting to reduce motion turned on.
-  // This prevents the animation from running when presenting the sheet, which results in
-  // the bottom sheet not even appearing so we need to override it to ensure the animation runs.
-  configs.reduceMotion = ReduceMotion.Never;
 
   // detect animation type
   const type =


### PR DESCRIPTION
Hello!

In https://github.com/gorhom/react-native-bottom-sheet/pull/1743 I introduced a fix for the sheet not appearing because of reduce motion settings. However, my implementation was faulty and caused a very annoying issue, which was fixed by @pafry7 flawlessly in https://github.com/gorhom/react-native-bottom-sheet/pull/1848. After I updated to v5, this issue started reappearing. When I looked at the source code for v5, I noticed that you preserved my implementation. This PR changes the implementation back to the one from @pafry7 one, so all credits go to them. 

I wasn't able to reproduce the issue in your example app, but I have confirmed locally that this diff works in my production app in which I was able to consistently reproduce it (it usually happened after I opened a sheet with dynamic sizing enabled, and then opened another one which had dynamic sizing disabled). I hope you can review and merge this PR.

Thank you!

