### PR TITLE
fix: added BottomSheetFlashList mock

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -109,6 +109,7 @@ module.exports = {
   BottomSheetScrollView: ReactNative.ScrollView,
   BottomSheetSectionList: ReactNative.SectionList,
   BottomSheetFlatList: ReactNative.FlatList,
+  BottomSheetFlashList: ReactNative.FlatList,
   BottomSheetVirtualizedList: ReactNative.VirtualizedList,
 
   TouchableOpacity: ReactNative.TouchableOpacity,


### PR DESCRIPTION
## Motivation

Current `mock.js` file lacks export for `BottomSheetFlashList`. Please let me know if simply assigning `ReactNative.FlatList` to it is fine or if I should try to conditionally import a real mock from `@shopify/flash-list`.

