### PR TITLE
fix:(web) useScrollHandler.web.ts does not pass scrollHandler, thus onEndReached fails to trigger

### DIFF
--- a/src/hooks/useScrollHandler.web.ts
+++ b/src/hooks/useScrollHandler.web.ts
@@ -2,7 +2,7 @@ import { type TouchEvent, useEffect, useRef } from 'react';
 import { findNodeHandle } from 'react-native';
 import { useSharedValue } from 'react-native-reanimated';
 import { ANIMATION_STATE, SCROLLABLE_STATE } from '../constants';
-import type { Scrollable } from '../types';
+import type { Scrollable, ScrollableEvent } from '../types';
 import { useBottomSheetInternal } from './useBottomSheetInternal';
 
 export type ScrollEventContextType = {
@@ -10,7 +10,7 @@ export type ScrollEventContextType = {
   shouldLockInitialPosition: boolean;
 };
 
-export const useScrollHandler = (_, onScroll) => {
+export const useScrollHandler = (_: never, onScroll?: ScrollableEvent) => {
   //#region refs
   const scrollableRef = useRef<Scrollable>(null);
   //#endregion

--- a/src/hooks/useScrollHandler.web.ts
+++ b/src/hooks/useScrollHandler.web.ts
@@ -10,7 +10,7 @@ export type ScrollEventContextType = {
   shouldLockInitialPosition: boolean;
 };
 
-export const useScrollHandler = () => {
+export const useScrollHandler = (_, onScroll) => {
   //#region refs
   const scrollableRef = useRef<Scrollable>(null);
   //#endregion
@@ -168,7 +168,7 @@ export const useScrollHandler = () => {
   //#endregion
 
   return {
-    scrollHandler: undefined,
+    scrollHandler: onScroll,
     scrollableRef,
     scrollableContentOffsetY,
   };


### PR DESCRIPTION
## Motivation

The current useScrollHandler.web.ts implementation passes `undefined` as scrollHandler on web, thus breaking `onEndReached`. This PR fixes the problem.

Found by my brother @intergalacticspacehighway, thanks 👑  - creating PR on his behalf! 