### PR TITLE
fix: stop any running animation, before early exiting due to same position

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -678,7 +678,6 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         }
 
         if (
-          position === animatedPosition.value ||
           position === undefined ||
           (animatedAnimationState.value === ANIMATION_STATE.RUNNING &&
             position === animatedNextPosition.value)
@@ -689,6 +688,10 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         // stop animation if it is running
         if (animatedAnimationState.value === ANIMATION_STATE.RUNNING) {
           stopAnimation();
+        }
+
+        if (position === animatedPosition.value) {
+          return;
         }
 
         /**


### PR DESCRIPTION
Fixes an edge case of `animateToPosition`, where it would early exit when `position === animatedPosition.value`, but wouldn't stop the currently running animation.
Therefore the bottom-sheet would proceed animating to an erroneous position.