### PR TITLE
Update mock.js for new reanimated functions

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -12,7 +12,7 @@ const React = require('react');
 const ReactNative = require('react-native');
 
 const NOOP = () => {};
-const NOOP_VALUE = { value: 0 };
+const NOOP_VALUE = { value: 0, set: NOOP, get: () => 0 };
 
 const BottomSheetModalProvider = ({ children }) => {
   return children;


### PR DESCRIPTION
Update the mock to work with react-native-reanimated 3.16

## Motivation

Allow the mock to work correctly when using the new `get` and `set` api in reanimated

