### PR TITLE
fix: replace useEffect with top level ref setting in useStableCallback

### DIFF
--- a/src/hooks/useStableCallback.ts
+++ b/src/hooks/useStableCallback.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 // biome-ignore lint: to be addressed!
 type Callback = (...args: any[]) => any;
@@ -8,16 +8,11 @@ type Callback = (...args: any[]) => any;
  */
 export const useStableCallback = (callback: Callback) => {
   const callbackRef = useRef<Callback>();
+  callbackRef.current = callback;
   const memoCallback = useCallback(
     // biome-ignore lint: to be addressed!
     (...args: any) => callbackRef.current && callbackRef.current(...args),
     []
   );
-  useEffect(() => {
-    callbackRef.current = callback;
-    return () => {
-      callbackRef.current = undefined;
-    };
-  });
   return memoCallback;
 };


### PR DESCRIPTION
## Motivation
Using `useEffect` to update the ref value causes potential issues with calling the callback before the first `useEffect` invocation. This happens for example in apps created with New Architecture. Setting the callback in the top level of the hook ensures that it is immediately ready to be called.
