### PR TITLE
feat: add generic type for data modal

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -22,22 +22,22 @@ import {
 import type {
   BottomSheetModalPrivateMethods,
   BottomSheetModalProps,
+  BottomSheetModalState,
 } from './types';
 
-type BottomSheetModal = BottomSheetModalMethods;
-
-const INITIAL_STATE: {
-  mount: boolean;
-  data?: never;
-} = {
+const INITIAL_STATE: BottomSheetModalState = {
   mount: false,
   data: undefined,
 };
 
-const BottomSheetModalComponent = forwardRef<
-  BottomSheetModal,
-  BottomSheetModalProps
->(function BottomSheetModal(props, ref) {
+// biome-ignore lint/suspicious/noExplicitAny: Using 'any' allows users to define their own strict types for 'data' property.
+type BottomSheetModal<T = any> = BottomSheetModalMethods<T>;
+
+// biome-ignore lint/suspicious/noExplicitAny: Using 'any' allows users to define their own strict types for 'data' property.
+function BottomSheetModalComponent<T = any>(
+  props: BottomSheetModalProps<T>,
+  ref: React.ForwardedRef<BottomSheetModal<T>>
+) {
   const {
     // modal props
     name,
@@ -62,7 +62,8 @@ const BottomSheetModalComponent = forwardRef<
   } = props;
 
   //#region state
-  const [{ mount, data }, setState] = useState(INITIAL_STATE);
+  const [{ mount, data }, setState] =
+    useState<BottomSheetModalState<T>>(INITIAL_STATE);
   //#endregion
 
   //#region hooks
@@ -190,7 +191,7 @@ const BottomSheetModalComponent = forwardRef<
   // biome-ignore lint/correctness/useExhaustiveDependencies(BottomSheetModal.name): used for debug only
   // biome-ignore lint/correctness/useExhaustiveDependencies(ref): ref is a stable object
   const handlePresent = useCallback(
-    function handlePresent(_data?: never) {
+    function handlePresent(_data?: T) {
       requestAnimationFrame(() => {
         setState({
           mount: true,
@@ -461,9 +462,20 @@ const BottomSheetModalComponent = forwardRef<
       </ContainerComponent>
     </Portal>
   ) : null;
-});
+}
 
-const BottomSheetModal = memo(BottomSheetModalComponent);
-BottomSheetModal.displayName = 'BottomSheetModal';
+const BottomSheetModal = memo(forwardRef(BottomSheetModalComponent)) as <
+  // biome-ignore lint/suspicious/noExplicitAny: Using 'any' allows users to define their own strict types for 'data' property.
+  T = any,
+>(
+  props: BottomSheetModalProps<T> & {
+    ref?: React.ForwardedRef<BottomSheetModal<T>>;
+  }
+) => ReturnType<typeof BottomSheetModalComponent>;
+(
+  BottomSheetModal as React.MemoExoticComponent<
+    typeof BottomSheetModalComponent
+  >
+).displayName = 'BottomSheetModal';
 
 export default BottomSheetModal;

--- a/src/components/bottomSheetModal/types.d.ts
+++ b/src/components/bottomSheetModal/types.d.ts
@@ -11,7 +11,8 @@ export interface BottomSheetModalPrivateMethods {
 
 export type BottomSheetModalStackBehavior = keyof typeof MODAL_STACK_BEHAVIOR;
 
-export interface BottomSheetModalProps
+// biome-ignore lint/suspicious/noExplicitAny: Using 'any' allows users to define their own strict types for 'data' property.
+export interface BottomSheetModalProps<T = any>
   extends Omit<BottomSheetProps, 'containerHeight' | 'onClose'> {
   /**
    * Modal name to help identify the modal for later on.
@@ -56,5 +57,11 @@ export interface BottomSheetModalProps
    * A scrollable node or normal view.
    * @type React.ReactNode[] | React.ReactNode | (({ data: any }?) => React.ReactElement)
    */
-  children: React.FC<{ data?: never }> | React.ReactNode[] | React.ReactNode;
+  children: React.FC<{ data?: T }> | React.ReactNode[] | React.ReactNode;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: Using 'any' allows users to define their own strict types for 'data' property.
+export interface BottomSheetModalState<T = any> {
+  mount: boolean;
+  data: T | undefined;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -81,12 +81,14 @@ export interface BottomSheetMethods {
    */
   forceClose: (animationConfigs?: WithSpringConfig | WithTimingConfig) => void;
 }
-export interface BottomSheetModalMethods extends BottomSheetMethods {
+
+// biome-ignore lint/suspicious/noExplicitAny: Using 'any' allows users to define their own strict types for 'data' property.
+export interface BottomSheetModalMethods<T = any> extends BottomSheetMethods {
   /**
    * Mount and present the bottom sheet modal to the initial snap point.
    * @param data to be passed to the modal.
    */
-  present: (data?: never) => void;
+  present: (data?: T) => void;
   /**
    * Close and unmount the bottom sheet modal.
    * @param animationConfigs snap animation configs.


### PR DESCRIPTION
## Motivation

This PR addresses an issue related to #2023.

It introduces the ability to explicitly define types for data passed through refs, ensuring strict typing for this data.

```typescript
const alertModalPrimaryRef = useRef<BottomSheetModal<AlertModalContentProps>>(null);

const handleUpdatePress = () => {
  alertModalPrimaryRef.current?.present({
      type: 'success',
      test: true,  // Throws error because `test` isn't defined in `AlertModalContentProps`
    })
}
```

Additionally, it would be beneficial if the data passed through children could also be typed.

```typescript
export type AlertModalContentProps = {
  type: 'success' | 'error'
}

...

<BottomSheetModal<AlertModalContentProps>
  name={name}
  ref={ref}>
  {({ data }) => (
    <BottomSheetView>
      {data && <AlertModalContent {...data} />}
    </BottomSheetView>
  )}
</BottomSheetModal>
```