### PR TITLE
fix[doc]: Change references to react-native-gesture-handler from v3 to v2

### DIFF
--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -64,7 +64,7 @@ npx expo install react-native-reanimated react-native-gesture-handler
 ```
 
 :::info
-**React Native Gesture Handler v3** needs extra steps to finalize its installation, please follow their [installation instructions](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation). Please **make sure** to wrap your App with `GestureHandlerRootView` when you've upgraded to React Native Gesture Handler ^3.
+**React Native Gesture Handler v2** needs extra steps to finalize its installation, please follow their [installation instructions](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation). Please **make sure** to wrap your App with `GestureHandlerRootView` when you've upgraded to React Native Gesture Handler ^2.
 
 **React Native Reanimated v3** needs extra steps to finalize its installation, please follow their [installation instructions](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started).
 :::


### PR DESCRIPTION
Change references to react-native-gesture-handler from v3 to v2

## Motivation

Went to upgrade to v5 and noticed the mentions of react-native-gesture-handler v3 on the homepage so naturally I went to upgrade that first ...only to realise RNGH is still only on v2 (which is also mentioned in the blog post here: https://gorhom.dev/react-native-bottom-sheet/blog/bottom-sheet-v5). Correct me if I'm wrong but I think the docs are supposed to say v2 where they currently say v3.