### PR TITLE
fix: prevent multiple calls for onClose event

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1836,7 +1836,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         /**
          * if index is `-1` than we fire the `onClose` callback.
          */
-        if (_animatedIndex === -1 && _providedOnClose) {
+        if (_animatedIndex === -1 && _animatedIndex !== animatedCurrentIndex.value && _providedOnClose) {
           if (__DEV__) {
             runOnJS(print)({
               component: BottomSheet.name,


### PR DESCRIPTION
currently `_providedOnClose` gets called potentially multiple times as this reanimated hook may (and likely will) run multiple times - I believe it should be called only once when changing `_animatedIndex` to `-1` only

## Motivation

if you perform some action `onClose`it may trigger multiple times.

