### PR TITLE
fix: handle unnecessary invocation of handleSnapToIndex on onAnimate …

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -6,6 +6,7 @@ import React, {
   useImperativeHandle,
   memo,
   useEffect,
+  useRef,
 } from 'react';
 import { type Insets, Platform } from 'react-native';
 import { State } from 'react-native-gesture-handler';
@@ -1854,14 +1855,21 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       [reduceMotion, handleOnChange, _providedOnClose]
     );
 
+    /** 
+     * Remember previously provided index, so that we don't cause
+     * unnecessary handleSnapToIndex
+     */
+    const previousProvidedIndex = useRef(_providedIndex)
+
     /**
      * React to `index` prop to snap the sheet to the new position.
      *
      * @alias onIndexChange
      */
     useEffect(() => {
-      if (isAnimatedOnMount.value) {
+      if (isAnimatedOnMount.value && previousProvidedIndex.current !== _providedIndex) {
         handleSnapToIndex(_providedIndex);
+        previousProvidedIndex.current = _providedIndex
       }
     }, [_providedIndex, isAnimatedOnMount, handleSnapToIndex]);
     //#endregion


### PR DESCRIPTION
…recreation

Please provide enough information so that others can review your pull request:

I create a ref which stores previous passed initial index and if [useEffect](https://github.com/gorhom/react-native-bottom-sheet/blob/master/src/components/bottomSheet/BottomSheet.tsx#L1862) is invoked again it checks whether the new **_providedIndex** actually does not equal to the old **_providedIndex**

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

https://github.com/gorhom/react-native-bottom-sheet/issues/2043
When we pass a prop **onAnimate** to **BottomSheet** we will encounter a bug, where **onAnimate**'s function recreation will cause a chain of dependency changes (**onAnimate** -> **_providedOnAnimate** -> **handleOnAnimate** -> **animateToPosition** -> **handleSnapToIndex** -> [useEffect](https://github.com/gorhom/react-native-bottom-sheet/blob/master/src/components/bottomSheet/BottomSheet.tsx#L1862)) which will cause our **BottomSheet** to snap back to the initial index (which is a wrong behaviour).
