### PR TITLE
Improve BottomSheet behavior for dynamic content and animation states

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -993,9 +993,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
               undefined,
               animationConfigs
             );
-            // Only set isAnimatedOnMount to true after animation starts
+            // Only set isAnimatedOnMount to true after animation completes
             if (source === ANIMATION_SOURCE.MOUNT) {
-              isAnimatedOnMount.value = true;
+              return;
             }
           } else {
             setToPosition(proposedPosition);


### PR DESCRIPTION
This commit enhances the BottomSheet component to better handle dynamic content changes and animation states. Key changes include:

- Added logic to manage the initial mount and dynamic content changes.
- Improved handling of closed states and snap point changes.
- Ensured that the closest snap point is returned when necessary.
- Refined the conditions under which the  flag is set.

**Risks:**
- Potential regressions in existing animation behavior if not thoroughly tested.
- Changes may introduce unexpected behavior in edge cases related to snap points.

**Benefits:**
- Improved user experience with more responsive and accurate positioning of the BottomSheet.
- Enhanced maintainability and clarity of the code regarding animation states.

Please provide enough information so that others can review your pull request:

## Motivation

# Fix Bottom Sheet Content Height Issues

## Overview
This PR fixes an issue where the bottom sheet would unexpectedly close when its content height changes. The current implementation incorrectly handles snap point changes during content updates, causing the sheet to close instead of maintaining its position.

## Key Problems Addressed
- Unwanted sheet closure during content height changes

## Solution
The patch improves position evaluation logic and adds proper state management to ensure the bottom sheet maintains expected behavior during content updates while preserving intended open/close functionality.

## Additional Changes
- Added debugging logs to help track sheet behavior for future troubleshooting if needed
