### PR TITLE
docs: fix mentioned gesture handle version

### DIFF
--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -64,7 +64,7 @@ npx expo install react-native-reanimated react-native-gesture-handler
 ```
 
 :::info
-**React Native Gesture Handler v3** needs extra steps to finalize its installation, please follow their [installation instructions](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation). Please **make sure** to wrap your App with `GestureHandlerRootView` when you've upgraded to React Native Gesture Handler ^3.
+**React Native Gesture Handler v2** needs extra steps to finalize its installation, please follow their [installation instructions](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation). Please **make sure** to wrap your App with `GestureHandlerRootView` when you've upgraded to React Native Gesture Handler ^2.
 
 **React Native Reanimated v3** needs extra steps to finalize its installation, please follow their [installation instructions](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started).
 :::


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

I didn't found a v3 of React Native Gesture Handler library, so I believe we want to mention v2 instead of v3 in this part of the docs.

