### PR TITLE
fixed bottom-sheet getting closed in initial render

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -976,7 +976,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          */
         if (
           animatedAnimationState.value !== ANIMATION_STATE.RUNNING &&
-          animatedCurrentIndex.value === -1
+          animatedCurrentIndex.value === -1 && animatedNextPositionIndex.value === -1
         ) {
           /**
            * early exit if reduce motion is enabled and index is out of sync with position.


### PR DESCRIPTION
## Motivation

So we faced an issue in which BottomSheet gets closed immediately after appearing.
I debugged it and found the root cause which is a race condition i.e. our initial render animation got finished and at the same time Snap-points changes
Now what happens is before the `animatedCurrentIndex` got changes to 1, evaluatePosition function got triggered due to snap changes and inside it goes in the closed condition block (since `animatedCurrentIndex` is still -1) and this causes the BottomSheet to get in closed state

### Fix
So for fixing this I simply added another check which is for `animatedNextPositionIndex` to check whether it is also -1 which will make sure we want that BottomSheet to be in closed state and then only we will trigger this closing

