### PR TITLE
[v5] Fix Bottom Sheet Closing on Orientation Change When Modal Exceeds Container Bounds

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1832,7 +1832,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         /**
          * if index is `-1` than we fire the `onClose` callback.
          */
-        if (_animatedIndex === -1 && _providedOnClose) {
+        if (_animatedIndex === -1 && _providedOnClose && _contentGestureState !== State.UNDETERMINED) {
           if (__DEV__) {
             runOnJS(print)({
               component: BottomSheet.name,


### PR DESCRIPTION
## Motivation:
This PR addresses an issue where the bottom sheet unexpectedly closes when the device orientation changes. The bug occurs when, during an orientation change, the modal's content size exceeds the bottom boundary of its container while the animation is in progress.

The root cause is that the closing logic gets triggered when the modal is detected as being out of bounds, even though no user interaction occurred. This fix ensures that the modal only closes if a user-initiated gesture is detected, preventing unintended dismissals caused by layout recalculations during orientation changes.

This issue specifically occurs when using` Dynamic Sizing[v5]` or the `useBottomSheetDynamicSnapPoints[v4]` hook.

Please review the attached videos below:

Not fixed - modal with small content - issue appears
https://github.com/user-attachments/assets/460db1b6-024b-42e3-9d7d-9a63a0d7cf66

Not fixed - modal with big content - no issue
https://github.com/user-attachments/assets/0b8f9653-f6e3-4de3-ae0e-ba28aa1334d0

Fixed - modal with small content - no issue
https://github.com/user-attachments/assets/1c8b5f8f-0625-457e-ac94-b279f14e9b55


Fixed - modal with small content - no issue
https://github.com/user-attachments/assets/c81ed1b4-3c6a-4344-ad61-7c20102b6f0c
