### PR TITLE
chore: add forwardRef to all eligible components

### DIFF
--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -1,4 +1,5 @@
 import React, {
+  forwardRef,
   memo,
   useCallback,
   useEffect,
@@ -30,7 +31,7 @@ import {
 import { styles } from './styles';
 import type { BottomSheetDefaultBackdropProps } from './types';
 
-const BottomSheetBackdropComponent = ({
+const BottomSheetBackdropComponent = forwardRef<Animated.View, BottomSheetDefaultBackdropProps>(({
   animatedIndex,
   opacity: _providedOpacity,
   appearsOnIndex: _providedAppearsOnIndex,
@@ -44,7 +45,7 @@ const BottomSheetBackdropComponent = ({
   accessibilityRole: _providedAccessibilityRole = DEFAULT_ACCESSIBILITY_ROLE,
   accessibilityLabel: _providedAccessibilityLabel = DEFAULT_ACCESSIBILITY_LABEL,
   accessibilityHint: _providedAccessibilityHint = DEFAULT_ACCESSIBILITY_HINT,
-}: BottomSheetDefaultBackdropProps) => {
+}) => {
   //#region hooks
   const { snapToIndex, close } = useBottomSheet();
   const isMounted = useRef(false);
@@ -159,7 +160,7 @@ const BottomSheetBackdropComponent = ({
   ) : (
     AnimatedView
   );
-};
+});
 
 const BottomSheetBackdrop = memo(BottomSheetBackdropComponent);
 BottomSheetBackdrop.displayName = 'BottomSheetBackdrop';

--- a/src/components/bottomSheetBackground/BottomSheetBackground.tsx
+++ b/src/components/bottomSheetBackground/BottomSheetBackground.tsx
@@ -1,20 +1,21 @@
-import React, { memo } from 'react';
+import React, { forwardRef, memo } from 'react';
 import { View } from 'react-native';
 import { styles } from './styles';
 import type { BottomSheetBackgroundProps } from './types';
 
-const BottomSheetBackgroundComponent = ({
+const BottomSheetBackgroundComponent = forwardRef<View,  BottomSheetBackgroundProps>(({
   pointerEvents,
   style,
-}: BottomSheetBackgroundProps) => (
+}, forwardedRef) => (
   <View
+    ref={forwardedRef}
     pointerEvents={pointerEvents}
     accessible={true}
     accessibilityRole="adjustable"
     accessibilityLabel="Bottom Sheet"
     style={[styles.container, style]}
   />
-);
+))
 
 const BottomSheetBackground = memo(BottomSheetBackgroundComponent);
 BottomSheetBackground.displayName = 'BottomSheetBackground';

--- a/src/components/bottomSheetContainer/BottomSheetContainer.tsx
+++ b/src/components/bottomSheetContainer/BottomSheetContainer.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo, useRef } from 'react';
+import React, { forwardRef, memo, useCallback, useMemo, useRef } from 'react';
 import {
   type LayoutChangeEvent,
   StatusBar,
@@ -10,8 +10,9 @@ import { WINDOW_HEIGHT } from '../../constants';
 import { print } from '../../utilities';
 import { styles } from './styles';
 import type { BottomSheetContainerProps } from './types';
+import { useCombinedRef } from 'src/hooks';
 
-function BottomSheetContainerComponent({
+const BottomSheetContainerComponent = forwardRef<View, BottomSheetContainerProps>(({
   containerHeight,
   containerOffset,
   topInset = 0,
@@ -20,8 +21,9 @@ function BottomSheetContainerComponent({
   detached,
   style,
   children,
-}: BottomSheetContainerProps) {
+}, forwardedRef) => {
   const containerRef = useRef<View>(null);
+  const ref = useCombinedRef(containerRef, forwardedRef)
   //#region styles
   const containerStyle = useMemo<StyleProp<ViewStyle>>(
     () => [
@@ -80,7 +82,7 @@ function BottomSheetContainerComponent({
   //#region render
   return (
     <View
-      ref={containerRef}
+      ref={ref}
       pointerEvents="box-none"
       onLayout={shouldCalculateHeight ? handleContainerLayout : undefined}
       style={containerStyle}
@@ -89,7 +91,7 @@ function BottomSheetContainerComponent({
     </View>
   );
   //#endregion
-}
+});
 
 const BottomSheetContainer = memo(BottomSheetContainerComponent);
 BottomSheetContainer.displayName = 'BottomSheetContainer';

--- a/src/components/bottomSheetDebugView/BottomSheetDebugView.tsx
+++ b/src/components/bottomSheetDebugView/BottomSheetDebugView.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { View } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 import ReText from './ReText';
@@ -8,7 +8,7 @@ interface BottomSheetDebugViewProps {
   values: Record<string, SharedValue<number | boolean> | number>;
 }
 
-const BottomSheetDebugView = ({ values }: BottomSheetDebugViewProps) => {
+const BottomSheetDebugView = forwardRef<View, BottomSheetDebugViewProps>(({ values }) => {
   return (
     <View pointerEvents="none" style={styles.container}>
       {Object.keys(values).map(key => (
@@ -21,6 +21,6 @@ const BottomSheetDebugView = ({ values }: BottomSheetDebugViewProps) => {
       ))}
     </View>
   );
-};
+});
 
 export default BottomSheetDebugView;

--- a/src/components/bottomSheetDraggableView/BottomSheetDraggableView.tsx
+++ b/src/components/bottomSheetDraggableView/BottomSheetDraggableView.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, memo } from 'react';
+import React, { useMemo, memo, forwardRef } from 'react';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
 import { BottomSheetDraggableContext } from '../../contexts/gesture';
@@ -8,13 +8,13 @@ import {
 } from '../../hooks';
 import type { BottomSheetDraggableViewProps } from './types';
 
-const BottomSheetDraggableViewComponent = ({
+const BottomSheetDraggableViewComponent = forwardRef<Animated.View, BottomSheetDraggableViewProps>(({
   nativeGestureRef,
   refreshControlGestureRef,
   style,
   children,
   ...rest
-}: BottomSheetDraggableViewProps) => {
+}, forwardedRef) => {
   //#region hooks
   const {
     enableContentPanningGesture,
@@ -109,13 +109,13 @@ const BottomSheetDraggableViewComponent = ({
   return (
     <GestureDetector gesture={draggableGesture}>
       <BottomSheetDraggableContext.Provider value={draggableGesture}>
-        <Animated.View style={style} {...rest}>
+        <Animated.View ref={forwardedRef} style={style} {...rest}>
           {children}
         </Animated.View>
       </BottomSheetDraggableContext.Provider>
     </GestureDetector>
   );
-};
+});
 
 const BottomSheetDraggableView = memo(BottomSheetDraggableViewComponent);
 BottomSheetDraggableView.displayName = 'BottomSheetDraggableView';

--- a/src/components/bottomSheetFooter/BottomSheetFooter.tsx
+++ b/src/components/bottomSheetFooter/BottomSheetFooter.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { forwardRef, memo, useCallback, useMemo } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { KEYBOARD_STATE } from '../../constants';
@@ -6,12 +6,12 @@ import { useBottomSheetInternal } from '../../hooks';
 import { styles } from './styles';
 import type { BottomSheetDefaultFooterProps } from './types';
 
-function BottomSheetFooterComponent({
+const BottomSheetFooterComponent = forwardRef<Animated.View, BottomSheetDefaultFooterProps>(({
   animatedFooterPosition,
   bottomInset = 0,
   style,
   children,
-}: BottomSheetDefaultFooterProps) {
+}, forwardedRef) => {
   //#region hooks
   const { animatedFooterHeight, animatedKeyboardState } =
     useBottomSheetInternal();
@@ -56,11 +56,11 @@ function BottomSheetFooterComponent({
   //#endregion
 
   return children !== null ? (
-    <Animated.View onLayout={handleContainerLayout} style={containerStyle}>
+    <Animated.View ref={forwardedRef} onLayout={handleContainerLayout} style={containerStyle}>
       {children}
     </Animated.View>
   ) : null;
-}
+});
 
 const BottomSheetFooter = memo(BottomSheetFooterComponent);
 BottomSheetFooter.displayName = 'BottomSheetFooter';

--- a/src/components/bottomSheetHandle/BottomSheetHandle.tsx
+++ b/src/components/bottomSheetHandle/BottomSheetHandle.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react';
+import React, { forwardRef, memo, useMemo } from 'react';
 import Animated from 'react-native-reanimated';
 import {
   DEFAULT_ACCESSIBILITY_HINT,
@@ -9,7 +9,7 @@ import {
 import { styles } from './styles';
 import type { BottomSheetDefaultHandleProps } from './types';
 
-const BottomSheetHandleComponent = ({
+const BottomSheetHandleComponent = forwardRef<Animated.View, BottomSheetDefaultHandleProps>(({
   style,
   indicatorStyle: _indicatorStyle,
   children,
@@ -17,7 +17,7 @@ const BottomSheetHandleComponent = ({
   accessibilityRole = DEFAULT_ACCESSIBILITY_ROLE,
   accessibilityLabel = DEFAULT_ACCESSIBILITY_LABEL,
   accessibilityHint = DEFAULT_ACCESSIBILITY_HINT,
-}: BottomSheetDefaultHandleProps) => {
+}, forwardedRef) => {
   // styles
   const containerStyle = useMemo(
     () => [styles.container, ...[Array.isArray(style) ? style : [style]]],
@@ -34,6 +34,7 @@ const BottomSheetHandleComponent = ({
   // render
   return (
     <Animated.View
+      ref={forwardedRef}
       style={containerStyle}
       accessible={accessible ?? undefined}
       accessibilityRole={accessibilityRole ?? undefined}
@@ -44,7 +45,7 @@ const BottomSheetHandleComponent = ({
       {children}
     </Animated.View>
   );
-};
+});
 
 const BottomSheetHandle = memo(BottomSheetHandleComponent);
 BottomSheetHandle.displayName = 'BottomSheetHandle';

--- a/src/components/bottomSheetView/BottomSheetView.tsx
+++ b/src/components/bottomSheetView/BottomSheetView.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useCallback, useMemo } from 'react';
+import React, { memo, useEffect, useCallback, useMemo, forwardRef } from 'react';
 import {
   type LayoutChangeEvent,
   StyleSheet,
@@ -10,14 +10,14 @@ import { useBottomSheetInternal } from '../../hooks';
 import { print } from '../../utilities';
 import type { BottomSheetViewProps } from './types';
 
-function BottomSheetViewComponent({
+const BottomSheetViewComponent = forwardRef<Animated.View, BottomSheetViewProps>(({
   focusHook: useFocusHook = useEffect,
   enableFooterMarginAdjustment = false,
   onLayout,
   style,
   children,
   ...rest
-}: BottomSheetViewProps) {
+}, forwardedRef) => {
   //#region hooks
   const {
     animatedScrollableContentOffsetY,
@@ -85,11 +85,11 @@ function BottomSheetViewComponent({
 
   //render
   return (
-    <Animated.View {...rest} onLayout={handleLayout} style={containerStyle}>
+    <Animated.View ref={forwardedRef} {...rest} onLayout={handleLayout} style={containerStyle}>
       {children}
     </Animated.View>
   );
-}
+})
 
 const BottomSheetView = memo(BottomSheetViewComponent);
 BottomSheetView.displayName = 'BottomSheetView';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -21,3 +21,4 @@ export { usePropsValidator } from './usePropsValidator';
 export { useAnimatedSnapPoints } from './useAnimatedSnapPoints';
 export { useReactiveSharedValue } from './useReactiveSharedValue';
 export { useBottomSheetGestureHandlers } from './useBottomSheetGestureHandlers';
+export { useCombinedRef } from "./useCombinedRef";

--- a/src/hooks/useCombinedRef.ts
+++ b/src/hooks/useCombinedRef.ts
@@ -1,0 +1,35 @@
+import { useCallback } from "react";
+
+/**
+ * Handles setting callback refs and MutableRefObjects.
+ * @param ref The ref to use for the instance.
+ * @param instance The instance being set.
+ */
+function setRef<TInstance>(ref: React.Ref<TInstance>, instance: TInstance) {
+  if (ref instanceof Function) {
+    ref(instance);
+  } else if (ref != null) {
+    // Force setting the ref.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    (ref as React.MutableRefObject<TInstance>).current = instance;
+  }
+}
+
+export function combinedRef<TInstance>(refs: React.Ref<TInstance>[]) {
+  return (instance: TInstance | null) => {
+    for (const ref of refs) {
+      setRef(ref, instance);
+    }
+  };
+}
+
+// CREDIT https://github.com/radix-ui/primitives/blob/main/packages/react/compose-refs/src/composeRefs.tsx
+/**
+ * Create a ref that passes its instance to multiple refs.
+ * @param refs The refs that should receive the instance.
+ * @returns The combined ref.
+ */
+export function useCombinedRef<TInstance>(...refs: React.Ref<TInstance>[]) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useCallback(combinedRef(refs), refs);
+}


### PR DESCRIPTION
## Motivation

When using styling libraries like Tamagui, it's often useful to wrap components like `<BottomSheetView>` with the `styled` function. However, these component wrapper functions require the use of `forwardRef` on their targets.

When viewing the source, there does not appear to be any reason why `forwardRef` cannot be used for many components. This PR simply wraps all eligible components and passes the `forwardedRef` to the inner components.

