### PR TITLE
Update peer dependency for reanimated to allow the use of reanimated v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react": "*",
     "react-native": "*",
     "react-native-gesture-handler": ">=2.16.1",
-    "react-native-reanimated": ">=3.16.0"
+    "react-native-reanimated": ">=3.16.0 || >=4.0.0-"
   },
   "peerDependenciesMeta": {
     "@types/react-native": {


### PR DESCRIPTION
## Motivation

Currently, running an application that uses react-native-bottom-sheet along with reanimated v4 causes a warning to be displayed :
```
The following packages should be updated for best compatibility with the installed expo version:
  react-native-reanimated@4.0.0-beta.3 - expected version: ~3.16.1
Your project may not work correctly until you install the expected versions of the packages.
```
The following changes will cause this warning not to be displayed, I tested with the example that is in the repository and everything works fine 
