### PR TITLE
Update RN version in example app to get rid off warning

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -33,3 +33,9 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+
+# ios
+ios/
+
+# android
+android/

--- a/example/package.json
+++ b/example/package.json
@@ -24,7 +24,7 @@
     "expo-status-bar": "~2.0.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-native": "0.76.7",
+    "react-native": "0.76.8",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-maps": "1.18.0",
     "react-native-pager-view": "6.5.1",


### PR DESCRIPTION
## Motivation
- Update RN version in example app to get rid off warning :
```
The following packages should be updated for best compatibility with the installed expo version:
  react-native@0.76.7 - expected version: 0.76.8
Your project may not work correctly until you install the expected versions of the packages.
```
- Add `ios` and `android` to `.gitignore`