### PR TITLE
Update custom-background guide to use non-deprecated method

### DIFF
--- a/website/docs/guides/custom-backdrop.mdx
+++ b/website/docs/guides/custom-backdrop.mdx
@@ -29,7 +29,7 @@ Here is an example of a custom backdrop component:
 import React, { useMemo } from "react";
 import { BottomSheetBackdropProps } from "@gorhom/bottom-sheet";
 import Animated, {
-  Extrapolate,
+  Extrapolation,
   interpolate,
   useAnimatedStyle,
 } from "react-native-reanimated";
@@ -41,7 +41,7 @@ const CustomBackdrop = ({ animatedIndex, style }: BottomSheetBackdropProps) => {
       animatedIndex.value,
       [0, 1],
       [0, 1],
-      Extrapolate.CLAMP
+      Extrapolation.CLAMP
     ),
   }));
 


### PR DESCRIPTION
## Motivation

Just an update for the custom backdrop guide to use the more recent `Extrapolation` enum rather than the now deprecated `Extrapolate` one. 

For context, this is the PR where reanimated decided to move towards the new enum: https://github.com/software-mansion/react-native-reanimated/pull/5141
