### PR TITLE
fix: prevent canceling touchmove events when not cancelable

### DIFF
--- a/src/hooks/useScrollHandler.web.ts
+++ b/src/hooks/useScrollHandler.web.ts
@@ -51,7 +51,7 @@ export const useScrollHandler = (_: never, onScroll?: ScrollableEvent) => {
     }
 
     function handleOnTouchMove(event: TouchEvent) {
-      if (animatedScrollableState.value === SCROLLABLE_STATE.LOCKED) {
+      if (animatedScrollableState.value === SCROLLABLE_STATE.LOCKED && event.cancelable) {
         return event.preventDefault();
       }
 
@@ -61,7 +61,7 @@ export const useScrollHandler = (_: never, onScroll?: ScrollableEvent) => {
         const touchY = event.touches[0].clientY;
         const touchYDelta = touchY - lastTouchY;
 
-        if (touchYDelta > 0) {
+        if (touchYDelta > 0 && event.cancelable) {
           return event.preventDefault();
         }
       }
@@ -92,7 +92,7 @@ export const useScrollHandler = (_: never, onScroll?: ScrollableEvent) => {
         animatedScrollableContentOffsetY.value = Math.max(0, scrollOffset);
       }
 
-      if (scrollOffset <= 0) {
+      if (scrollOffset <= 0 && event.cancelable) {
         event.preventDefault();
         event.stopPropagation();
         return false;


### PR DESCRIPTION
## Description

This PR fixes warnings about attempting to cancel touchmove events with cancelable=false by adding checks for the event.cancelable property before calling preventDefault().

## Details

The error 'Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted' occurs when the code tries to call preventDefault() on a touchmove event that has cancelable=false (which happens during active scrolling).

The fix adds event.cancelable checks in all three places where preventDefault() is called in the useScrollHandler.web.ts file.