### PR TITLE
fix: set containerHeight to value or initial container height

### DIFF
--- a/src/components/bottomSheetContainer/BottomSheetContainer.tsx
+++ b/src/components/bottomSheetContainer/BottomSheetContainer.tsx
@@ -7,6 +7,7 @@ import {
   type ViewStyle,
 } from 'react-native';
 import { WINDOW_HEIGHT } from '../../constants';
+import { INITIAL_CONTAINER_HEIGHT } from '../bottomSheet/constants';
 import { print } from '../../utilities';
 import { styles } from './styles';
 import type { BottomSheetContainerProps } from './types';
@@ -44,7 +45,7 @@ function BottomSheetContainerComponent({
         layout: { height },
       },
     }: LayoutChangeEvent) {
-      containerHeight.value = height;
+      containerHeight.value = height || INITIAL_CONTAINER_HEIGHT;
 
       containerRef.current?.measure(
         (_x, _y, _width, _height, _pageX, pageY) => {


### PR DESCRIPTION
Fixes opening the bottom-sheet on navigating back to a screen with a bottom-sheet while using react-native-web. See [Issue 1910](https://github.com/gorhom/react-native-bottom-sheet/issues/1910)

