### PR TITLE
feat: Add position params in onAnimate event

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -544,7 +544,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
             category: 'callback',
             params: {
               toIndex: targetIndex,
+              toPosition: targetPosition,
               fromIndex: animatedCurrentIndex.value,
+              fromPosition: animatedPosition.value,
             },
           });
         }
@@ -648,10 +650,15 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         animatedNextPosition.value = position;
 
         /**
-         * offset the position if keyboard is shown
+         * offset the position if keyboard is shown,
+         * and behavior not extend.
          */
         let offset = 0;
-        if (animatedKeyboardState.value === KEYBOARD_STATE.SHOWN) {
+        if (
+          animatedKeyboardState.value === KEYBOARD_STATE.SHOWN &&
+          keyboardBehavior !== KEYBOARD_BEHAVIOR.extend &&
+          position < animatedPosition.value
+        ) {
           offset = animatedKeyboardHeightInContainer.value;
         }
 
@@ -677,6 +684,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       },
       [
         handleOnAnimate,
+        keyboardBehavior,
         _providedAnimationConfigs,
         _providedOverrideReduceMotion,
       ]

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -536,7 +536,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     );
     // biome-ignore lint/correctness/useExhaustiveDependencies(BottomSheet.name): used for debug only
     const handleOnAnimate = useCallback(
-      function handleOnAnimate(targetIndex: number) {
+      function handleOnAnimate(targetIndex: number, targetPosition: number) {
         if (__DEV__) {
           print({
             component: BottomSheet.name,
@@ -554,10 +554,15 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         }
 
         if (targetIndex !== animatedCurrentIndex.value) {
-          _providedOnAnimate(animatedCurrentIndex.value, targetIndex);
+          _providedOnAnimate(
+            animatedCurrentIndex.value,
+            targetIndex,
+            animatedPosition.value,
+            targetPosition
+          );
         }
       },
-      [_providedOnAnimate, animatedCurrentIndex]
+      [_providedOnAnimate, animatedCurrentIndex, animatedPosition]
     );
     //#endregion
 
@@ -657,7 +662,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         /**
          * fire `onAnimate` callback
          */
-        runOnJS(handleOnAnimate)(animatedNextPositionIndex.value);
+        runOnJS(handleOnAnimate)(animatedNextPositionIndex.value, position);
 
         /**
          * start animation

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -264,9 +264,14 @@ export interface BottomSheetProps
   /**
    * Callback when the sheet about to animate to a new position.
    *
-   * @type (fromIndex: number, toIndex: number) => void;
+   * @type (fromIndex: number, toIndex: number, fromPosition: number, toPosition: number) => void;
    */
-  onAnimate?: (fromIndex: number, toIndex: number) => void;
+  onAnimate?: (
+    fromIndex: number,
+    toIndex: number,
+    fromPosition: number,
+    toPosition: number
+  ) => void;
   //#endregion
 
   //#region components

--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -379,11 +379,16 @@ function BottomSheetModalComponent<T = any>(
     [_providedOnChange]
   );
   const handleBottomSheetOnAnimate = useCallback(
-    (fromIndex: number, toIndex: number) => {
+    (
+      fromIndex: number,
+      toIndex: number,
+      fromPosition: number,
+      toPosition: number
+    ) => {
       nextIndexRef.current = toIndex;
 
       if (_providedOnAnimate) {
-        _providedOnAnimate(fromIndex, toIndex);
+        _providedOnAnimate(fromIndex, toIndex, fromPosition, toPosition);
       }
     },
     [_providedOnAnimate]

--- a/website/docs/props.md
+++ b/website/docs/props.md
@@ -372,7 +372,7 @@ type onChange = (index: number) => void;
 Callback when the sheet about to animate to a new position.
 
 ```ts
-type onAnimate = (fromIndex: number, toIndex: number) => void;
+type onAnimate = (fromIndex: number, toIndex: number, fromPosition: number, toPosition: number) => void;
 ```
 
 | type     | default | required |


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Add `fromPosition` and `toPosition` params to the `onAnimate` event.

## Motivation
There are certain cases where this could be useful (we already have the position info in the `onChange` callback). For example, when the sheets is animating to a position that is not part of the specified snap points, the `toIndex` will be `-1` (which is expected since the snap point does not exist) even though the sheet will be closed. See [this issue](https://github.com/gorhom/react-native-bottom-sheet/issues/2255) for instance.

