### PR TITLE
Fix animatedIndex when enableDynamicSizing = true

### DIFF
--- a/src/hooks/useAnimatedSnapPoints.ts
+++ b/src/hooks/useAnimatedSnapPoints.ts
@@ -27,7 +27,10 @@ import { normalizeSnapPoint } from '../utilities';
  * Helper function to extract snap points from props
  */
 const extractSnapPoints = (snapPoints: BottomSheetProps['snapPoints']) =>
-  snapPoints ? ('value' in snapPoints ? snapPoints.value : snapPoints) : [];
+ {
+  'worklet';
+  return snapPoints ? ('value' in snapPoints ? snapPoints.value : snapPoints) : []
+};
 
 export const useAnimatedSnapPoints = (
   snapPoints: BottomSheetProps['snapPoints'],

--- a/src/hooks/useAnimatedSnapPoints.ts
+++ b/src/hooks/useAnimatedSnapPoints.ts
@@ -23,6 +23,15 @@ import { normalizeSnapPoint } from '../utilities';
  * @param maxDynamicContentSize
  * @returns {SharedValue<number[]>}
  */
+/**
+ * Helper function to extract snap points from props
+ */
+const extractSnapPoints = (snapPoints: BottomSheetProps['snapPoints']) =>
+ {
+  'worklet';
+  return snapPoints ? ('value' in snapPoints ? snapPoints.value : snapPoints) : []
+};
+
 export const useAnimatedSnapPoints = (
   snapPoints: BottomSheetProps['snapPoints'],
   containerHeight: SharedValue<number>,
@@ -33,66 +42,53 @@ export const useAnimatedSnapPoints = (
   maxDynamicContentSize: BottomSheetProps['maxDynamicContentSize']
 ): [SharedValue<number[]>, SharedValue<number>, SharedValue<boolean>] => {
   const dynamicSnapPointIndex = useSharedValue<number>(-1);
+  
   const normalizedSnapPoints = useDerivedValue(() => {
-    // early exit, if container layout is not ready
-    const isContainerLayoutReady =
-      containerHeight.value !== INITIAL_CONTAINER_HEIGHT;
-    if (!isContainerLayoutReady) {
+    // Early exit if container layout is not ready
+    if (containerHeight.value === INITIAL_CONTAINER_HEIGHT) {
       return [INITIAL_SNAP_POINT];
     }
 
-    // extract snap points from provided props
-    const _snapPoints = snapPoints
-      ? 'value' in snapPoints
-        ? snapPoints.value
-        : snapPoints
-      : [];
+    const rawSnapPoints = extractSnapPoints(snapPoints);
 
-    // normalized all provided snap points, converting percentage
-    // values into absolute values.
-    let _normalizedSnapPoints = _snapPoints.map(snapPoint =>
-      normalizeSnapPoint(snapPoint, containerHeight.value)
-    ) as number[];
+    // Normalize all provided snap points, converting percentage values to absolute values
+    const normalizedSet = new Set(
+      rawSnapPoints.map((snapPoint: string | number) =>
+        normalizeSnapPoint(snapPoint, containerHeight.value)
+      ) as number[]
+    );
 
-    // return normalized snap points if dynamic sizing is not enabled
+    // Return early if dynamic sizing is not enabled
     if (!enableDynamicSizing) {
-      return _normalizedSnapPoints;
+      return Array.from(normalizedSet).sort((a, b) => b - a);
     }
 
-    // early exit, if handle height is not calculated yet.
+    // Early exit if handle height is not calculated yet
     if (handleHeight.value === INITIAL_HANDLE_HEIGHT) {
       return [INITIAL_SNAP_POINT];
     }
 
-    // early exit, if content height is not calculated yet.
+    // Early exit if content height is not calculated yet
     if (contentHeight.value === INITIAL_CONTAINER_HEIGHT) {
       return [INITIAL_SNAP_POINT];
     }
 
-    // calculate a new snap point based on content height.
+    // Calculate dynamic snap point based on content height
+    const maxContentSize = maxDynamicContentSize ?? containerHeight.value;
     const dynamicSnapPoint =
       containerHeight.value -
-      Math.min(
-        contentHeight.value + handleHeight.value,
-        maxDynamicContentSize !== undefined
-          ? maxDynamicContentSize
-          : containerHeight.value
-      );
+      Math.min(contentHeight.value + handleHeight.value, maxContentSize);
 
-    // push dynamic snap point into the normalized snap points,
-    // only if it does not exists in the provided list already.
-    if (!_normalizedSnapPoints.includes(dynamicSnapPoint)) {
-      _normalizedSnapPoints.push(dynamicSnapPoint);
-    }
+    // Add dynamic snap point to the set (automatically handles duplicates)
+    normalizedSet.add(dynamicSnapPoint);
 
-    // sort all snap points.
-    _normalizedSnapPoints = _normalizedSnapPoints.sort((a, b) => b - a);
+    // Convert to sorted array
+    const sortedSnapPoints = Array.from(normalizedSet).sort((a, b) => b - a);
 
-    // locate the dynamic snap point index.
-    dynamicSnapPointIndex.value =
-      _normalizedSnapPoints.indexOf(dynamicSnapPoint);
+    // Update dynamic snap point index
+    dynamicSnapPointIndex.value = sortedSnapPoints.indexOf(dynamicSnapPoint);
 
-    return _normalizedSnapPoints;
+    return sortedSnapPoints;
   }, [
     snapPoints,
     containerHeight,
@@ -105,31 +101,15 @@ export const useAnimatedSnapPoints = (
   ]);
 
   const hasDynamicSnapPoint = useDerivedValue(() => {
-    /**
-     * if dynamic sizing is enabled, then we return true.
-     */
+    // If dynamic sizing is enabled, return true
     if (enableDynamicSizing) {
       return true;
     }
 
-    // extract snap points from provided props
-    const _snapPoints = snapPoints
-      ? 'value' in snapPoints
-        ? snapPoints.value
-        : snapPoints
-      : [];
+    const rawSnapPoints = extractSnapPoints(snapPoints);
 
-    /**
-     * if any of the snap points provided is a string, then we return true.
-     */
-    if (
-      _snapPoints.length &&
-      _snapPoints.find(snapPoint => typeof snapPoint === 'string')
-    ) {
-      return true;
-    }
-
-    return false;
+    // If any snap point is a string, return true
+    return rawSnapPoints.some((snapPoint: string | number) => typeof snapPoint === 'string');
   });
 
   return [normalizedSnapPoints, dynamicSnapPointIndex, hasDynamicSnapPoint];

--- a/src/hooks/useAnimatedSnapPoints.ts
+++ b/src/hooks/useAnimatedSnapPoints.ts
@@ -23,6 +23,12 @@ import { normalizeSnapPoint } from '../utilities';
  * @param maxDynamicContentSize
  * @returns {SharedValue<number[]>}
  */
+/**
+ * Helper function to extract snap points from props
+ */
+const extractSnapPoints = (snapPoints: BottomSheetProps['snapPoints']) =>
+  snapPoints ? ('value' in snapPoints ? snapPoints.value : snapPoints) : [];
+
 export const useAnimatedSnapPoints = (
   snapPoints: BottomSheetProps['snapPoints'],
   containerHeight: SharedValue<number>,
@@ -33,66 +39,53 @@ export const useAnimatedSnapPoints = (
   maxDynamicContentSize: BottomSheetProps['maxDynamicContentSize']
 ): [SharedValue<number[]>, SharedValue<number>, SharedValue<boolean>] => {
   const dynamicSnapPointIndex = useSharedValue<number>(-1);
+  
   const normalizedSnapPoints = useDerivedValue(() => {
-    // early exit, if container layout is not ready
-    const isContainerLayoutReady =
-      containerHeight.value !== INITIAL_CONTAINER_HEIGHT;
-    if (!isContainerLayoutReady) {
+    // Early exit if container layout is not ready
+    if (containerHeight.value === INITIAL_CONTAINER_HEIGHT) {
       return [INITIAL_SNAP_POINT];
     }
 
-    // extract snap points from provided props
-    const _snapPoints = snapPoints
-      ? 'value' in snapPoints
-        ? snapPoints.value
-        : snapPoints
-      : [];
+    const rawSnapPoints = extractSnapPoints(snapPoints);
 
-    // normalized all provided snap points, converting percentage
-    // values into absolute values.
-    let _normalizedSnapPoints = _snapPoints.map(snapPoint =>
-      normalizeSnapPoint(snapPoint, containerHeight.value)
-    ) as number[];
+    // Normalize all provided snap points, converting percentage values to absolute values
+    const normalizedSet = new Set(
+      rawSnapPoints.map((snapPoint: string | number) =>
+        normalizeSnapPoint(snapPoint, containerHeight.value)
+      ) as number[]
+    );
 
-    // return normalized snap points if dynamic sizing is not enabled
+    // Return early if dynamic sizing is not enabled
     if (!enableDynamicSizing) {
-      return _normalizedSnapPoints;
+      return Array.from(normalizedSet).sort((a, b) => b - a);
     }
 
-    // early exit, if handle height is not calculated yet.
+    // Early exit if handle height is not calculated yet
     if (handleHeight.value === INITIAL_HANDLE_HEIGHT) {
       return [INITIAL_SNAP_POINT];
     }
 
-    // early exit, if content height is not calculated yet.
+    // Early exit if content height is not calculated yet
     if (contentHeight.value === INITIAL_CONTAINER_HEIGHT) {
       return [INITIAL_SNAP_POINT];
     }
 
-    // calculate a new snap point based on content height.
+    // Calculate dynamic snap point based on content height
+    const maxContentSize = maxDynamicContentSize ?? containerHeight.value;
     const dynamicSnapPoint =
       containerHeight.value -
-      Math.min(
-        contentHeight.value + handleHeight.value,
-        maxDynamicContentSize !== undefined
-          ? maxDynamicContentSize
-          : containerHeight.value
-      );
+      Math.min(contentHeight.value + handleHeight.value, maxContentSize);
 
-    // push dynamic snap point into the normalized snap points,
-    // only if it does not exists in the provided list already.
-    if (!_normalizedSnapPoints.includes(dynamicSnapPoint)) {
-      _normalizedSnapPoints.push(dynamicSnapPoint);
-    }
+    // Add dynamic snap point to the set (automatically handles duplicates)
+    normalizedSet.add(dynamicSnapPoint);
 
-    // sort all snap points.
-    _normalizedSnapPoints = _normalizedSnapPoints.sort((a, b) => b - a);
+    // Convert to sorted array
+    const sortedSnapPoints = Array.from(normalizedSet).sort((a, b) => b - a);
 
-    // locate the dynamic snap point index.
-    dynamicSnapPointIndex.value =
-      _normalizedSnapPoints.indexOf(dynamicSnapPoint);
+    // Update dynamic snap point index
+    dynamicSnapPointIndex.value = sortedSnapPoints.indexOf(dynamicSnapPoint);
 
-    return _normalizedSnapPoints;
+    return sortedSnapPoints;
   }, [
     snapPoints,
     containerHeight,
@@ -105,31 +98,15 @@ export const useAnimatedSnapPoints = (
   ]);
 
   const hasDynamicSnapPoint = useDerivedValue(() => {
-    /**
-     * if dynamic sizing is enabled, then we return true.
-     */
+    // If dynamic sizing is enabled, return true
     if (enableDynamicSizing) {
       return true;
     }
 
-    // extract snap points from provided props
-    const _snapPoints = snapPoints
-      ? 'value' in snapPoints
-        ? snapPoints.value
-        : snapPoints
-      : [];
+    const rawSnapPoints = extractSnapPoints(snapPoints);
 
-    /**
-     * if any of the snap points provided is a string, then we return true.
-     */
-    if (
-      _snapPoints.length &&
-      _snapPoints.find(snapPoint => typeof snapPoint === 'string')
-    ) {
-      return true;
-    }
-
-    return false;
+    // If any snap point is a string, return true
+    return rawSnapPoints.some((snapPoint: string | number) => typeof snapPoint === 'string');
   });
 
   return [normalizedSnapPoints, dynamicSnapPointIndex, hasDynamicSnapPoint];


### PR DESCRIPTION
[Fixes #2295](https://github.com/gorhom/react-native-bottom-sheet/issues/2295).

if enableDynamicSizing was true, the dynamic endpoints were getting pushed twice into the array. this would cause animated index to be 0 for a frame, since there was a duplicate closed index (one at index 0, and another at index -1). This caused the backdrop to flicker as it depended on an accurate animatedIndex for the opacity of the background.

fix: make the snap points a set and then turn it into an array. this way guarantees no duplicates.