### PR TITLE
fix: replace JSX with `React.createElement`in mock implementation

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -50,11 +50,9 @@ class BottomSheetModal extends React.Component {
 
   render() {
     const { children: Content } = this.props;
-    return typeof Content === 'function' ? (
-      <Content data={this.data} />
-    ) : (
-      Content
-    );
+    return typeof Content === 'function'
+      ? React.createElement(Content, { data: this.data })
+      : Content;
   }
 }
 


### PR DESCRIPTION
## Motivation

Fixing mock from https://github.com/gorhom/react-native-bottom-sheet/pull/2265

## Problem

The mock implementation in mock.js was using JSX syntax (`<Content data={this.data} />`), which caused a `SyntaxError: Unexpected token '<'` on some projects.

This forces users to add `@gorhom/bottom-sheet` to their Jest `transformIgnorePatterns` configuration to enable JSX transformation for the mock file:

```js
transformIgnorePatterns: [
  "node_modules/(?!@gorhom/bottom-sheet|...other packages)"
]
```

## Solution:

Replaced JSX syntax with `React.createElement(Content, { data: this.data })` in the BottomSheetModal mock component.

This ensures the mock works in all JavaScript environments without requiring JSX transformation
