### PR TITLE
Fix findNodeHandle.web.ts for BottomSheetFlatList

### DIFF
--- a/src/utilities/findNodeHandle.web.ts
+++ b/src/utilities/findNodeHandle.web.ts
@@ -22,6 +22,14 @@ export function findNodeHandle(
     }
   } catch {}
 
+  try {
+      // @ts-ignore
+    nodeHandle = componentOrHandle.getScrollableNode();
+    if (nodeHandle) {
+      return nodeHandle;
+    }
+  } catch {}
+
   // @ts-ignore https://github.com/facebook/react-native/blob/a314e34d6ee875830d36e4df1789a897c7262056/packages/virtualized-lists/Lists/VirtualizedList.js#L1252
   nodeHandle = componentOrHandle._scrollRef;
   if (nodeHandle) {


### PR DESCRIPTION
## Motivation

When using BottomSheetFlatList with react-native-web, the web implementation of findNodeHandle fails to locate the scrollable node for FlatList. However, this node can be accessed via the [getScrollableNode](https://github.com/necolas/react-native-web/blob/0.20.0/packages/react-native-web/src/vendor/react-native/FlatList/index.js#L408) method.
This PR adds support for retrieving the scrollable node using getScrollableNode, ensuring proper functionality on the web.