### PR TITLE
feat(android): add bottom tab bar height property

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -132,6 +132,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       containerOffset: _providedContainerOffset,
       topInset = 0,
       bottomInset = 0,
+      android_bottomTabBarHeight = 0,
       maxDynamicContentSize,
 
       // animated callback shared values
@@ -180,6 +181,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         enableDynamicSizing,
         topInset,
         bottomInset,
+        android_bottomTabBarHeight,
       });
     }
     //#endregion
@@ -1553,7 +1555,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
                     Math.abs(bottomInset - animatedContainerOffset.value.bottom)
                 )
               : Math.abs(
-                  _keyboardHeight - animatedContainerOffset.value.bottom
+                  _keyboardHeight - animatedContainerOffset.value.bottom -
+                    (Platform.OS === 'android' ? android_bottomTabBarHeight : 0)
                 );
 
         /**

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -136,6 +136,13 @@ export interface BottomSheetProps
    */
   bottomInset?: number;
   /**
+   * Bottom tab bar height value helps to avoid extra padding below text input on android,
+   * usually comes from `@react-navigation/bottom-tabs` hook `useBottomTabBarHeight`.
+   * @type number
+   * @default 0
+   */
+  android_bottomTabBarHeight?: number;
+  /**
    * Max dynamic content size height to limit the bottom sheet height
    * from exceeding a provided size.
    * @type number

--- a/src/hooks/usePropsValidator.ts
+++ b/src/hooks/usePropsValidator.ts
@@ -14,9 +14,10 @@ export const usePropsValidator = ({
   enableDynamicSizing,
   topInset,
   bottomInset,
+  android_bottomTabBarHeight,
 }: Pick<
   BottomSheetProps,
-  'index' | 'snapPoints' | 'enableDynamicSizing' | 'topInset' | 'bottomInset'
+  'index' | 'snapPoints' | 'enableDynamicSizing' | 'topInset' | 'bottomInset' | 'android_bottomTabBarHeight'
 >) => {
   useMemo(() => {
     //#region snap points
@@ -73,6 +74,10 @@ export const usePropsValidator = ({
     invariant(
       typeof bottomInset === 'number' || typeof bottomInset === 'undefined',
       `'bottomInset' was provided but with wrong type ! expected type is a number.`
+    );
+    invariant(
+      typeof android_bottomTabBarHeight === 'number' || typeof android_bottomTabBarHeight === 'undefined',
+      `'android_bottomTabBarHeight' was provided but with wrong type ! expected type is a number.`
     );
     //#endregion
 

--- a/src/hooks/usePropsValidator.ts
+++ b/src/hooks/usePropsValidator.ts
@@ -82,5 +82,5 @@ export const usePropsValidator = ({
     //#endregion
 
     // animations
-  }, [index, snapPoints, topInset, bottomInset, enableDynamicSizing]);
+  }, [index, snapPoints, topInset, bottomInset, enableDynamicSizing, android_bottomTabBarHeight]);
 };


### PR DESCRIPTION
## Motivation

Add a new property to fix extra padding below text input on android when the bottom sheet is inside a stack that contains a bottom tab bar.

The provided value usually comes from `@react-navigation/bottom-tabs` hook `useBottomTabBarHeight`.

Before the feature proposed on this PR, I had to dynamically change `bottomInset` based on the keyboard state, which was causing the bottom sheet to randomly close instead of collapsing, and also performance issues due to state change during animation.

## Tests
- Works as expected with and without a bottom tab bar
- Continues to work nice on iOS (we ignore the value)

## Screenshots
Collapsed|Issue (extra padding)|Fixed
-|-|-
![collapsed](https://github.com/user-attachments/assets/bedb6a7a-04a2-4365-bef2-20f7b75e7af0)|![extra-padding](https://github.com/user-attachments/assets/85f75803-5874-4233-9ae2-7ca28398639f)|![expected](https://github.com/user-attachments/assets/c63e573f-0273-4356-94b8-8bf1cb2e2d65)

