### PR TITLE
fix: prevent re-renders when toggling enableContentPanningGesture

### DIFF
--- a/src/components/bottomSheet/BottomSheetContent.tsx
+++ b/src/components/bottomSheet/BottomSheetContent.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useMemo } from 'react';
 import type { ViewProps, ViewStyle } from 'react-native';
-import Animated, {
+import {
   type AnimatedStyle,
   useAnimatedStyle,
   useDerivedValue,
@@ -41,7 +41,6 @@ function BottomSheetContentComponent({
   const {
     enableDynamicSizing,
     overDragResistanceFactor,
-    enableContentPanningGesture,
     animatedPosition,
     animatedHandleHeight,
     animatedHighestSnapPoint,
@@ -229,11 +228,8 @@ function BottomSheetContentComponent({
   //#endregion
 
   //#region render
-  const DraggableView = enableContentPanningGesture
-    ? BottomSheetDraggableView
-    : Animated.View;
   return (
-    <DraggableView
+    <BottomSheetDraggableView
       accessible={accessible}
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}
@@ -241,7 +237,7 @@ function BottomSheetContentComponent({
       style={contentContainerStyle}
     >
       {children}
-    </DraggableView>
+    </BottomSheetDraggableView>
   );
   //#endregion
 }


### PR DESCRIPTION
## Description

This PR fixes an issue where toggling the `enableContentPanningGesture` prop causes the entire content area to re-render due to component swapping between `BottomSheetDraggableView` and `Animated.View`.

## Problem

The current implementation conditionally renders different components based on `enableContentPanningGesture`:

```tsx
const DraggableView = enableContentPanningGesture
  ? BottomSheetDraggableView
  : Animated.View;
```

This causes:
- Full component unmount/remount when toggling the gesture
- Loss of internal component state
- Unnecessary re-renders
- Poor user experience when dynamically controlling gestures

## Solution

Always use `BottomSheetDraggableView` regardless of the `enableContentPanningGesture` value. The component already handles enable/disable logic internally via `.enabled(enableContentPanningGesture)` on the gesture handler.

### Related issue

Fixes #2330 