### PR TITLE
try getScrollableNode in findNodeHandle.web.ts

### DIFF
--- a/src/utilities/findNodeHandle.web.ts
+++ b/src/utilities/findNodeHandle.web.ts
@@ -22,6 +22,14 @@ export function findNodeHandle(
     }
   } catch {}
 
+  try {
+    // @ts-ignore
+    nodeHandle = componentOrHandle.getScrollableNode();
+    if (nodeHandle) {
+      return nodeHandle;
+    }
+  } catch {}
+
   // @ts-ignore https://github.com/facebook/react-native/blob/a314e34d6ee875830d36e4df1789a897c7262056/packages/virtualized-lists/Lists/VirtualizedList.js#L1252
   nodeHandle = componentOrHandle._scrollRef;
   if (nodeHandle) {


### PR DESCRIPTION
## Motivation

a follow up to https://github.com/gorhom/react-native-bottom-sheet/pull/2292#issuecomment-2910535509, i realized that i'm still getting an issue on `BottomSheetSectionList` (and maybe others?) on web like

<img width="766" height="558" alt="image" src="https://github.com/user-attachments/assets/d81433de-eee2-419f-8589-e416e0fd18b8" />
