### PR TITLE
fix(#2356): added missing dependencies to callback hooks

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -605,7 +605,16 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         animatedNextPositionIndex.value = INITIAL_VALUE;
         animatedContainerHeightDidChange.value = false;
       },
-      []
+      [
+        animatedAnimationSource,
+        animatedAnimationState,
+        animatedContainerHeightDidChange,
+        animatedCurrentIndex.value,
+        animatedNextPosition,
+        animatedNextPositionIndex,
+        isAnimatedOnMount,
+        isForcedClosing,
+      ]
     );
     const animateToPosition: AnimateToPositionType = useCallback(
       function animateToPosition(
@@ -690,6 +699,16 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         keyboardBehavior,
         _providedAnimationConfigs,
         _providedOverrideReduceMotion,
+        animateToPositionCompleted,
+        animatedAnimationSource,
+        animatedAnimationState,
+        animatedKeyboardHeightInContainer,
+        animatedKeyboardState,
+        animatedNextPosition,
+        animatedNextPositionIndex,
+        animatedPosition,
+        animatedSnapPoints,
+        stopAnimation,
       ]
     );
     /**
@@ -697,43 +716,52 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
      *
      * @param targetPosition position to be set.
      */
-    const setToPosition = useCallback(function setToPosition(
-      targetPosition: number
-    ) {
-      'worklet';
-      if (
-        targetPosition === animatedPosition.value ||
-        targetPosition === undefined ||
-        (animatedAnimationState.value === ANIMATION_STATE.RUNNING &&
-          targetPosition === animatedNextPosition.value)
-      ) {
-        return;
-      }
+    const setToPosition = useCallback(
+      function setToPosition(targetPosition: number) {
+        'worklet';
+        if (
+          targetPosition === animatedPosition.value ||
+          targetPosition === undefined ||
+          (animatedAnimationState.value === ANIMATION_STATE.RUNNING &&
+            targetPosition === animatedNextPosition.value)
+        ) {
+          return;
+        }
 
-      if (__DEV__) {
-        runOnJS(print)({
-          component: BottomSheet.name,
-          method: setToPosition.name,
-          params: {
-            currentPosition: animatedPosition.value,
-            targetPosition,
-          },
-        });
-      }
+        if (__DEV__) {
+          runOnJS(print)({
+            component: 'BottomSheet',
+            method: setToPosition.name,
+            params: {
+              currentPosition: animatedPosition.value,
+              targetPosition,
+            },
+          });
+        }
 
-      /**
-       * store next position
-       */
-      animatedNextPosition.value = targetPosition;
-      animatedNextPositionIndex.value =
-        animatedSnapPoints.value.indexOf(targetPosition);
+        /**
+         * store next position
+         */
+        animatedNextPosition.value = targetPosition;
+        animatedNextPositionIndex.value =
+          animatedSnapPoints.value.indexOf(targetPosition);
 
-      stopAnimation();
+        stopAnimation();
 
-      // set values
-      animatedPosition.value = targetPosition;
-      animatedContainerHeightDidChange.value = false;
-    }, []);
+        // set values
+        animatedPosition.value = targetPosition;
+        animatedContainerHeightDidChange.value = false;
+      },
+      [
+        animatedAnimationState,
+        animatedContainerHeightDidChange,
+        animatedNextPosition,
+        animatedNextPositionIndex,
+        animatedPosition,
+        animatedSnapPoints,
+        stopAnimation,
+      ]
+    );
     //#endregion
 
     //#region private methods
@@ -845,6 +873,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         keyboardBehavior,
         keyboardBlurBehavior,
         _providedIndex,
+        android_keyboardInputMode,
+        animatedClosedPosition,
       ]
     );
 
@@ -969,7 +999,25 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           animationConfigs
         );
       },
-      [getEvaluatedPosition, animateToPosition, setToPosition, reduceMotion]
+      [
+        getEvaluatedPosition,
+        animateToPosition,
+        setToPosition,
+        reduceMotion,
+        animateOnMount,
+        animatedAnimationState,
+        animatedClosedPosition,
+        animatedContainerHeightDidChange,
+        animatedCurrentIndex,
+        animatedIndex,
+        animatedNextPositionIndex,
+        animatedPosition,
+        animatedSnapPoints,
+        isAnimatedOnMount,
+        isForcedClosing,
+        isInTemporaryPosition,
+        isLayoutCalculated,
+      ]
     );
     //#endregion
 
@@ -1039,7 +1087,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         'worklet';
         if (__DEV__) {
           print({
-            component: BottomSheet.name,
+            component: 'BottomSheet',
             method: handleSnapToPosition.name,
             params: {
               position,
@@ -1083,12 +1131,11 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       },
       [
         animateToPosition,
-        bottomInset,
-        topInset,
         isLayoutCalculated,
         isForcedClosing,
         animatedContainerHeight,
-        animatedPosition,
+        animatedNextPosition,
+        isInTemporaryPosition,
       ]
     );
     // biome-ignore lint/correctness/useExhaustiveDependencies(BottomSheet.name): used for debug only

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -609,7 +609,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         animatedAnimationSource,
         animatedAnimationState,
         animatedContainerHeightDidChange,
-        animatedCurrentIndex.value,
+        animatedCurrentIndex,
         animatedNextPosition,
         animatedNextPositionIndex,
         isAnimatedOnMount,

--- a/src/hooks/useGestureEventsHandlersDefault.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.tsx
@@ -1,9 +1,6 @@
 import { useCallback } from 'react';
 import { Keyboard, Platform } from 'react-native';
-import {
-  runOnJS,
-  useSharedValue,
-} from 'react-native-reanimated';
+import { runOnJS, useSharedValue } from 'react-native-reanimated';
 import {
   ANIMATION_SOURCE,
   GESTURE_SOURCE,
@@ -110,6 +107,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
         animatedPosition,
         animatedKeyboardState,
         animatedScrollableContentOffsetY,
+        context,
       ]
     );
     const handleOnChange: GestureEventHandlerCallbackType = useCallback(
@@ -267,6 +265,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
         animatedPosition,
         animatedScrollableType,
         animatedScrollableContentOffsetY,
+        context,
       ]
     );
     const handleOnEnd: GestureEventHandlerCallbackType = useCallback(
@@ -401,17 +400,17 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
         animatedSnapPoints,
         animatedScrollableContentOffsetY,
         animateToPosition,
+        context,
       ]
     );
 
-    const handleOnFinalize: GestureEventHandlerCallbackType =
-      useCallback(
-        function handleOnFinalize() {
-          'worklet';
-          resetContext(context);
-        },
-        [context]
-      );
+    const handleOnFinalize: GestureEventHandlerCallbackType = useCallback(
+      function handleOnFinalize() {
+        'worklet';
+        resetContext(context);
+      },
+      [context]
+    );
     //#endregion
 
     return {

--- a/src/hooks/useGestureEventsHandlersDefault.web.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.web.tsx
@@ -1,9 +1,6 @@
 import { useCallback } from 'react';
 import { Keyboard, Platform } from 'react-native';
-import {
-  runOnJS,
-  useSharedValue,
-} from 'react-native-reanimated';
+import { runOnJS, useSharedValue } from 'react-native-reanimated';
 import {
   ANIMATION_SOURCE,
   GESTURE_SOURCE,
@@ -94,6 +91,7 @@ export const useGestureEventsHandlersDefault = () => {
       animatedPosition,
       animatedKeyboardState,
       animatedScrollableContentOffsetY,
+      context,
     ]
   );
   const handleOnChange: GestureEventHandlerCallbackType = useCallback(
@@ -249,6 +247,7 @@ export const useGestureEventsHandlersDefault = () => {
       animatedPosition,
       animatedScrollableType,
       animatedScrollableContentOffsetY,
+      context,
     ]
   );
   const handleOnEnd: GestureEventHandlerCallbackType = useCallback(
@@ -383,6 +382,7 @@ export const useGestureEventsHandlersDefault = () => {
       animatedSnapPoints,
       animatedScrollableContentOffsetY,
       animateToPosition,
+      context,
     ]
   );
   const handleOnFinalize: GestureEventHandlerCallbackType = useCallback(

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -75,7 +75,14 @@ export const useKeyboard = () => {
       keyboardState.value = state;
       temporaryCachedKeyboardEvent.value = [];
     },
-    []
+    [
+      keyboardAnimationDuration,
+      keyboardAnimationEasing,
+      keyboardHeight,
+      keyboardState,
+      shouldHandleKeyboardEvents,
+      temporaryCachedKeyboardEvent,
+    ]
   );
   //#endregion
 

--- a/src/hooks/useScrollEventsHandlersDefault.ts
+++ b/src/hooks/useScrollEventsHandlersDefault.ts
@@ -66,6 +66,7 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
         scrollableContentOffsetY,
         animatedScrollableState,
         animatedSheetState,
+        animatedHandleGestureState,
       ]
     );
   const handleOnBeginDrag: ScrollEventHandlerCallbackType<ScrollEventContextType> =


### PR DESCRIPTION
## Motivation

#2356 had migrated `useWorkletCallback` to normal `useCallback` but the migration missed updating the dependencies array