### PR TITLE
fix(ally): missing background component props override

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -167,6 +167,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         _providedAccessibilityLabel = DEFAULT_ACCESSIBILITY_LABEL,
       accessibilityRole:
         _providedAccessibilityRole = DEFAULT_ACCESSIBILITY_ROLE,
+      accessibleBackground,
+      accessibilityBackgroundLabel,
+      accessibilityBackgroundRole,
     } = props;
     //#endregion
 
@@ -1852,6 +1855,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
                 {backgroundComponent === null ? null : (
                   <BottomSheetBackgroundContainer
                     key="BottomSheetBackgroundContainer"
+                    accessible={accessibleBackground}
+                    accessibilityLabel={accessibilityBackgroundLabel}
+                    accessibilityRole={accessibilityBackgroundRole}
                     animatedIndex={animatedIndex}
                     animatedPosition={animatedPosition}
                     backgroundComponent={backgroundComponent}

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import type { Insets, StyleProp, View, ViewStyle } from 'react-native';
+import type {AccessibilityRole, Insets, StyleProp, View, ViewStyle} from 'react-native';
 import type { PanGesture } from 'react-native-gesture-handler';
 import type {
   AnimateStyle,
@@ -105,6 +105,9 @@ export interface BottomSheetProps
    * @default ReduceMotion.System
    */
   overrideReduceMotion?: ReduceMotion;
+  accessibleBackground: boolean;
+  accessibilityBackgroundLabel?: string;
+  accessibilityBackgroundRole?: AccessibilityRole;
   //#endregion
 
   //#region layout

--- a/src/components/bottomSheetBackground/BottomSheetBackground.tsx
+++ b/src/components/bottomSheetBackground/BottomSheetBackground.tsx
@@ -2,16 +2,24 @@ import React, { memo } from 'react';
 import { View } from 'react-native';
 import { styles } from './styles';
 import type { BottomSheetBackgroundProps } from './types';
+import {
+  DEFAULT_ACCESSIBILITY_LABEL,
+  DEFAULT_ACCESSIBILITY_ROLE,
+  DEFAULT_ACCESSIBLE
+} from "./constants";
 
 const BottomSheetBackgroundComponent = ({
+  accessible = DEFAULT_ACCESSIBLE,
+  accessibilityLabel = DEFAULT_ACCESSIBILITY_LABEL,
+  accessibilityRole = DEFAULT_ACCESSIBILITY_ROLE,
   pointerEvents,
   style,
 }: BottomSheetBackgroundProps) => (
   <View
     pointerEvents={pointerEvents}
-    accessible={true}
-    accessibilityRole="adjustable"
-    accessibilityLabel="Bottom Sheet"
+    accessible={accessible}
+    accessibilityRole={accessibilityRole}
+    accessibilityLabel={accessibilityLabel}
     style={[styles.background, style]}
   />
 );

--- a/src/components/bottomSheetBackground/BottomSheetBackgroundContainer.tsx
+++ b/src/components/bottomSheetBackground/BottomSheetBackgroundContainer.tsx
@@ -5,6 +5,9 @@ import { styles } from './styles';
 import type { BottomSheetBackgroundContainerProps } from './types';
 
 const BottomSheetBackgroundContainerComponent = ({
+  accessible,
+  accessibilityLabel,
+  accessibilityRole,
   animatedIndex,
   animatedPosition,
   backgroundComponent: _providedBackgroundComponent,
@@ -21,6 +24,9 @@ const BottomSheetBackgroundContainerComponent = ({
     _providedBackgroundComponent ?? BottomSheetBackground;
   return (
     <BackgroundComponent
+      accessible={accessible}
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole={accessibilityRole}
       pointerEvents="none"
       animatedIndex={animatedIndex}
       animatedPosition={animatedPosition}

--- a/src/components/bottomSheetBackground/constants.ts
+++ b/src/components/bottomSheetBackground/constants.ts
@@ -1,0 +1,11 @@
+// accessibility
+const DEFAULT_ACCESSIBLE = true;
+const DEFAULT_ACCESSIBILITY_LABEL = 'Bottom Sheet';
+const DEFAULT_ACCESSIBILITY_ROLE = 'adjustable';
+
+export {
+  // accessibility
+  DEFAULT_ACCESSIBLE,
+  DEFAULT_ACCESSIBILITY_LABEL,
+  DEFAULT_ACCESSIBILITY_ROLE,
+};

--- a/src/components/bottomSheetBackground/types.d.ts
+++ b/src/components/bottomSheetBackground/types.d.ts
@@ -2,7 +2,7 @@ import type { ViewProps } from 'react-native';
 import type { BottomSheetVariables } from '../../types';
 import type { BottomSheetProps } from '../bottomSheet';
 export interface BottomSheetBackgroundProps
-  extends Pick<ViewProps, 'pointerEvents' | 'style'>,
+  extends Pick<ViewProps, 'pointerEvents' | 'style' | 'accessible' | 'accessibilityLabel' | 'accessibilityRole'>,
     BottomSheetVariables {}
 
 export type BottomSheetBackgroundContainerProps = Pick<


### PR DESCRIPTION
## Motivation

This PR aims to make the `BackgroundComponent` more accessible by:

1. Removing the hardcoded accessibility props;
2. Allowing accessibility props injection from the parent BottomSheet component;

By default this component isn't customizable and we ran into an issue where our client wants to disable the accessibility of that component to focus only on the content itself.

