### PR TITLE
Adding more accssibility props from provided props

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -167,6 +167,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         _providedAccessibilityLabel = DEFAULT_ACCESSIBILITY_LABEL,
       accessibilityRole:
         _providedAccessibilityRole = DEFAULT_ACCESSIBILITY_ROLE,
+      accessibilityLabelledBy: _providedAccessibilityLabelledBy,
+      accessibilityState: _providedAccessibilityState,
+      role: _providedRole,
     } = props;
     //#endregion
 
@@ -1773,6 +1776,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
                   accessible={_providedAccessible ?? undefined}
                   accessibilityRole={_providedAccessibilityRole ?? undefined}
                   accessibilityLabel={_providedAccessibilityLabel ?? undefined}
+                  accessibilityLabelledBy={_providedAccessibilityLabelledBy ?? undefined}
+                  accessibilityState={_providedAccessibilityState ?? undefined}
+                  role={_providedRole}
                   keyboardBehavior={keyboardBehavior}
                   detached={detached}
                 >


### PR DESCRIPTION
Adding more accssibility props from provided props:
- `role`
- `accessibilityLabelledBy`
- `accessibilityState`

## Motivation
A bottom sheet (similar to a modal) can work as an alert or a dialog, even depending on some cases it can be a menu, a list or a radiogroup . 

The default accessibility role `adjustable` does not represent that, plus even when can be overwritten the accessibilityRole is limited in options vs the [role](https://reactnative.dev/docs/accessibility#role) prop.

In this PR we are just allowing the role to be passed down so this should be backwards compatible and up to consumer to customize. Similar thing with the accessibilityState and accessibilityLabelledBy. Those are usefull tools that were not supported and adding that support is backwards compatible.

accessibilityState can include a `{ expanded: boolean }` to represent if is open or not.
accessibilityLabelledBy is usefull for bottom sheets that has a title/heading element we can bind. 

However to prevent any breacking change for existing users we just do not default any value, just allow consumers to provide them.
