### PR TITLE
fix(#2445): modal closing with input auto focus

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -636,7 +636,11 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         if (
           status === KEYBOARD_STATUS.SHOWN &&
           keyboardBehavior !== KEYBOARD_BEHAVIOR.extend &&
-          [ANIMATION_SOURCE.KEYBOARD, ANIMATION_SOURCE.SNAP_POINT_CHANGE].includes(source)
+          [
+            ANIMATION_SOURCE.KEYBOARD,
+            ANIMATION_SOURCE.SNAP_POINT_CHANGE,
+            ANIMATION_SOURCE.MOUNT,
+          ].includes(source)
         ) {
           offset = heightWithinContainer;
         }


### PR DESCRIPTION
Fix #2445 

https://snack.expo.dev/@pakerwreah/bottom-sheet-modal---auto-close-on-mount

https://github.com/user-attachments/assets/369b2f96-31fa-4225-b2b2-dc121bd78368

## Motivation

Opening a modal containing a text input with autoFocus cause the modal to instant close.
Happens on v5.2.4 and v5.2.5 but works fine on v5.2.3.

