### PR TITLE
fix(#2455): wrong index reported by modal + TextInput + autofocus

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -659,7 +659,12 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           status === KEYBOARD_STATUS.SHOWN &&
           position !== closedDetentPosition
         ) {
-          index = highestDetentPosition ?? DEFAULT_KEYBOARD_INDEX;
+          if (detents && highestDetentPosition) {
+            index = detents.indexOf(highestDetentPosition)
+          }
+          if (index === -1) {
+            index = DEFAULT_KEYBOARD_INDEX;
+          }
         }
 
         /**

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -659,8 +659,8 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           status === KEYBOARD_STATUS.SHOWN &&
           position !== closedDetentPosition
         ) {
-          if (detents && highestDetentPosition) {
-            index = detents.indexOf(highestDetentPosition)
+          if (detents !== undefined && highestDetentPosition !== undefined) {
+            index = detents.indexOf(highestDetentPosition);
           }
           if (index === -1) {
             index = DEFAULT_KEYBOARD_INDEX;


### PR DESCRIPTION
Fix #2455

## Motivation

The new fallback logic to fix TextInput with autofocus is mixing "position" with "index", leading to corrupted behavior.
(see issue for more details)

