### PR TITLE
fix: set keyboard height to 0 on TextInput blur

### DIFF
--- a/src/components/bottomSheetTextInput/BottomSheetTextInput.tsx
+++ b/src/components/bottomSheetTextInput/BottomSheetTextInput.tsx
@@ -63,6 +63,7 @@ const BottomSheetTextInputComponent = forwardRef<
         animatedKeyboardState.set(state => ({
           ...state,
           target: undefined,
+          height: 0,
         }));
       }
 
@@ -100,6 +101,7 @@ const BottomSheetTextInputComponent = forwardRef<
         animatedKeyboardState.set(state => ({
           ...state,
           target: undefined,
+          height: 0,
         }));
       }
 


### PR DESCRIPTION
This fixes an issue where the bottom sheet does not restore down to the bottom of the screen when the input blurs and the software keyboard is hidden.

Ensure that the modal's height + software keyboard height is greater than the screen height. Otherwise you won't experience the bug.

Issue reproduction: https://github.com/goknsh/react-native-bottom-sheet-repro