### PR TITLE
fix: stack behavior is not working when using with ref callback

### DIFF
--- a/example/src/screens/modal/StackExample.tsx
+++ b/example/src/screens/modal/StackExample.tsx
@@ -3,7 +3,7 @@ import {
   BottomSheetModal,
   useBottomSheetModal,
 } from '@gorhom/bottom-sheet';
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { ForwardedRef, useCallback, useMemo, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Button } from '../../components/button';
 import { ContactList } from '../../components/contactList';
@@ -15,7 +15,7 @@ const StackExample = () => {
   const { dismiss, dismissAll } = useBottomSheetModal();
 
   // refs
-  const bottomSheetModalARef = useRef<BottomSheetModal>(null);
+  const bottomSheetModalARef = useRef<BottomSheetModal | null>(null);
   const bottomSheetModalBRef = useRef<BottomSheetModal>(null);
   const bottomSheetModalCRef = useRef<BottomSheetModal>(null);
 
@@ -23,6 +23,11 @@ const StackExample = () => {
   const snapPoints = useMemo(() => ['25%', '50%'], []);
 
   // callbacks
+  const assignBottomSheetModalARef = useCallback((ref: BottomSheetModal | null) => {
+    if(ref){
+      bottomSheetModalARef.current = ref
+    }
+  }, [])
   const handlePresentAPress = useCallback(() => {
     if (bottomSheetModalARef.current) {
       bottomSheetModalARef.current.present();
@@ -106,7 +111,7 @@ const StackExample = () => {
 
       <BottomSheetModal
         name="A"
-        ref={bottomSheetModalARef}
+        ref={assignBottomSheetModalARef}
         snapPoints={snapPoints}
         enableDynamicSizing={false}
         handleComponent={renderHeaderHandle('Modal A')}

--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -86,6 +86,7 @@ function BottomSheetModalComponent<T = any>(
   const forcedDismissed = useRef(false);
   const mounted = useRef(false);
   mounted.current = mount;
+  const internalRef = useRef<BottomSheetModalMethods | null>(null);
   //#endregion
 
   //#region variables
@@ -187,7 +188,7 @@ function BottomSheetModalComponent<T = any>(
 
   //#region bottom sheet modal methods
   // biome-ignore lint/correctness/useExhaustiveDependencies(BottomSheetModal.name): used for debug only
-  // biome-ignore lint/correctness/useExhaustiveDependencies(ref): ref is a stable object
+  // biome-ignore lint/correctness/useExhaustiveDependencies(internalRef): internalRef is a stable object
   const handlePresent = useCallback(
     function handlePresent(_data?: T) {
       requestAnimationFrame(() => {
@@ -197,10 +198,10 @@ function BottomSheetModalComponent<T = any>(
         });
         mountSheet(
           key,
-          ref as unknown as RefObject<BottomSheetModalPrivateMethods>,
+          internalRef as unknown as RefObject<BottomSheetModalPrivateMethods>,
           stackBehavior
         );
-        ref;
+        internalRef;
 
         if (__DEV__) {
           print({
@@ -416,21 +417,38 @@ function BottomSheetModalComponent<T = any>(
   //#endregion
 
   //#region expose methods
-  useImperativeHandle(ref, () => ({
-    // sheet
-    snapToIndex: handleSnapToIndex,
-    snapToPosition: handleSnapToPosition,
-    expand: handleExpand,
-    collapse: handleCollapse,
-    close: handleClose,
-    forceClose: handleForceClose,
-    // modal methods
-    dismiss: handleDismiss,
-    present: handlePresent,
-    // internal
-    minimize: handleMinimize,
-    restore: handleRestore,
-  }));
+  const internalSheetApi = useMemo(() => {
+    return {
+      // sheet
+      snapToIndex: handleSnapToIndex,
+      snapToPosition: handleSnapToPosition,
+      expand: handleExpand,
+      collapse: handleCollapse,
+      close: handleClose,
+      forceClose: handleForceClose,
+      // modal methods
+      dismiss: handleDismiss,
+      present: handlePresent,
+      // internal
+      minimize: handleMinimize,
+      restore: handleRestore,
+    }
+  }, [
+    handleSnapToIndex,
+    handleSnapToPosition,
+    handleExpand,
+    handleCollapse,
+    handleClose,
+    handleForceClose,
+    handleDismiss,
+    handlePresent,
+    handleMinimize,
+    handleRestore,
+  ])
+
+  internalRef.current = internalSheetApi
+  
+  useImperativeHandle(ref, () => internalSheetApi, [internalSheetApi]);
   //#endregion
 
   // render


### PR DESCRIPTION
## Motivation

When using `BottomSheetModal` with ref callback like so
```
<BottomSheetModal 
   ref={() => {}}
/>
```
The `handlePresent` in `BottomSheetModal` was using the passed in `ref`. This caused the `mountSheet` to not execute as expected when the passed in `ref` is a callback function. This PR fixes [this](https://github.com/gorhom/react-native-bottom-sheet/issues/2463).

