### PR TITLE
fix: clear temporary increase in height when keyboard is hidden

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1709,13 +1709,14 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         }
 
         /**
-         * if new keyboard state is hidden and blur behavior is none, then exit the method
+         * if new keyboard state is hidden and blur behavior is none,
+         * clear temporary position so evaluatePosition can snap to detent.
          */
         if (
           status === KEYBOARD_STATUS.HIDDEN &&
           keyboardBlurBehavior === KEYBOARD_BLUR_BEHAVIOR.none
         ) {
-          return;
+          isInTemporaryPosition.value = false;
         }
 
         const animationConfigs = getKeyboardAnimationConfigs(easing, duration);


### PR DESCRIPTION
Hello from Replit 👋

## Motivation

We're running into this bug where if you open the keyboard open and the size of the bottom sheet increases, if you *do not* swipe down to close the keyboard and blur the text input some other way, the size of the bottom sheet does not reset, leaving it unnecessarily larger

https://github.com/user-attachments/assets/c45ce0d7-06ad-42f0-9968-86f594d59f57

This PR fixes it 😊

https://github.com/user-attachments/assets/5c5805f4-9c8f-4433-8e96-eb081b93b2f6


