### PR TITLE
feat(backdrop): support custom pressBehavior

### DIFF
--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -9,11 +9,11 @@ import React, {
 import type { ViewProps } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
-  interpolate,
-  useAnimatedStyle,
-  useAnimatedReaction,
-  runOnJS,
   Extrapolation,
+  interpolate,
+  runOnJS,
+  useAnimatedReaction,
+  useAnimatedStyle,
 } from 'react-native-reanimated';
 import { useBottomSheet } from '../../hooks';
 import {
@@ -73,6 +73,8 @@ const BottomSheetBackdropComponent = ({
       close();
     } else if (pressBehavior === 'collapse') {
       snapToIndex(disappearsOnIndex as number);
+    } else if (pressBehavior === 'custom') {
+      // do nothing, only onPress will be called
     } else if (typeof pressBehavior === 'number') {
       snapToIndex(pressBehavior);
     }

--- a/src/components/bottomSheetBackdrop/types.d.ts
+++ b/src/components/bottomSheetBackdrop/types.d.ts
@@ -4,13 +4,17 @@ import type {
   BottomSheetVariables,
   NullableAccessibilityProps,
 } from '../../types';
-import type { BottomSheetProps } from '../bottomSheet/types';
 
 export interface BottomSheetBackdropProps
   extends Pick<ViewProps, 'style'>,
     BottomSheetVariables {}
 
-export type BackdropPressBehavior = 'none' | 'close' | 'collapse' | number;
+export type BackdropPressBehavior =
+  | 'none'
+  | 'close'
+  | 'collapse'
+  | 'custom'
+  | number;
 
 export interface BottomSheetDefaultBackdropProps
   extends BottomSheetBackdropProps,

--- a/website/docs/components/bottomsheetbackdrop.md
+++ b/website/docs/components/bottomsheetbackdrop.md
@@ -68,7 +68,7 @@ What should happen when user press backdrop?
 - `none`: do nothing, and `onPress` prop will be ignored.
 - `close`: close the sheet.
 - `collapse`: collapse the sheet.
-- `custom`: only `onPress` function will be called
+- `custom`: only `onPress` function will be called.
 - `N`: snap point index.
 
 | type                              | default | required |

--- a/website/docs/components/bottomsheetbackdrop.md
+++ b/website/docs/components/bottomsheetbackdrop.md
@@ -68,6 +68,7 @@ What should happen when user press backdrop?
 - `none`: do nothing, and `onPress` prop will be ignored.
 - `close`: close the sheet.
 - `collapse`: collapse the sheet.
+- `custom`: only `onPress` function will be called
 - `N`: snap point index.
 
 | type                              | default | required |


### PR DESCRIPTION
## Motivation
Backdrop pressBehavior currently only allows one of the default actions `close` `collapse` `snap to number` `none`.
This PR allows for another option called `custom` which does nothing other than calling the provided onPress function, but it still allows the backdrop to be pressed contrary to the `none` option.

Using this option might conflict with the existing accessibility hint behavior since it will result in `Tap to custom the Bottom Sheet` string being passed as the accessibility hint, so i wonder if you'd like to add a warning for that.

This option does not really require any extra checks other than allowing the string `custom` as a valid type, the extra if check is just added for code readability.

