### PR TITLE
fix: ts compile error on Animated has no exported member EasingFunction

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,7 +68,7 @@ enum SNAP_POINT_TYPE {
   DYNAMIC = 1,
 }
 
-const ANIMATION_EASING: Animated.EasingFunction = Easing.out(Easing.exp);
+const ANIMATION_EASING: EasingFunction = Easing.out(Easing.exp);
 const ANIMATION_DURATION = 250;
 
 const ANIMATION_CONFIGS = Platform.select<TimingConfig | SpringConfig>({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,5 @@
 import { Dimensions, Platform } from 'react-native';
-import type Animated from 'react-native-reanimated';
-import { Easing } from 'react-native-reanimated';
+import { Easing, EasingFunction } from 'react-native-reanimated';
 import type { SpringConfig, TimingConfig } from './types';
 
 const { height: WINDOW_HEIGHT, width: WINDOW_WIDTH } = Dimensions.get('window');


### PR DESCRIPTION
With the latest react-native-reanimated version, and expo sdk 54 (new arch), I got a ts compile error from this library

tsc --build --noEmit

error TS2694: Namespace '"/Users/michielleunens/Documents/code/allride_app/node_modules/react-native-reanimated/lib/typescript/Animated"' has no exported member 'EasingFunction'

I've updated the import locally like this and I was able to compile again



