### PR TITLE
Update constants.ts

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -69,7 +69,7 @@ enum SNAP_POINT_TYPE {
   DYNAMIC = 1,
 }
 
-const ANIMATION_EASING: Animated.EasingFunction = Easing.out(Easing.exp);
+const ANIMATION_EASING = Easing.out(Easing.exp);
 const ANIMATION_DURATION = 250;
 
 const ANIMATION_CONFIGS = Platform.select<TimingConfig | SpringConfig>({


### PR DESCRIPTION
## Motivation

This PR fixes a TypeScript typing issue in `react-native-reanimated` where the `EasingFunction` type is being imported but not exported from the `Animated` namespace.  

Currently, this results in the following error during compilation:

```
Namespace '.../node_modules/react-native-reanimated/lib/typescript/Animated'
has no exported member 'EasingFunction'.
```
