### PR TITLE
fix: keyboard reaction not triggering on subsequent opens (iOS physic…

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1610,8 +1610,11 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
      * @alias OnKeyboardStateChange
      */
     useAnimatedReaction(
-      () =>
-        animatedKeyboardState.get().status + animatedKeyboardState.get().height,
+      () => {
+        const state = animatedKeyboardState.get();
+        // CRITICAL FIX: Add target to reaction to ensure it triggers on subsequent keyboard opens
+        return state.status + state.height + (state.target || 0);
+      },
       (result, _previousResult) => {
         /**
          * if keyboard state is equal to the previous state, then exit the method
@@ -1691,6 +1694,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
             return;
           }
         }
+
         animatedKeyboardState.set(state => ({
           ...state,
           heightWithinContainer,


### PR DESCRIPTION
## 🐛 Issue
After first keyboard open/close cycle on iOS physical devices, subsequent keyboard opens would not properly animate bottom sheet position. Only affected physical iOS devices - iOS Simulator worked fine.

## 🔍 Root Cause  
`useAnimatedReaction` dependency in `BottomSheet.tsx` only included `status + height`, which remained identical across subsequent keyboard opens, causing React Native's change detection to skip the reaction callback.

## 💡 Solution
Include keyboard `target` in reaction dependency to ensure reaction triggers on every keyboard open, regardless of identical height/status values.

The `target` changes on each `TextInput` focus, guaranteeing unique dependency values.

## 📋 Changes
- **BottomSheet.tsx**: Add `(state.target || 0)` to keyboard reaction dependency
- Single line fix with zero breaking changes
- Maintains all existing functionality and performance optimizations

## ✅ Testing
- [x] iOS physical device keyboard behavior now works correctly
- [x] Subsequent keyboard opens animate properly  
- [x] No regression on Android or iOS Simulator
- [x] All keyboard behaviors (`fillParent`, `extend`, `interactive`) working

## 🎯 Impact
Fixes keyboard behavior regression that existed since target tracking was introduced for TextInput focus management. Critical fix for iOS physical device users.