### PR TITLE
fix: getBoundingClientRect undefined check

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,5 @@
   },
   "overrides": {
     "conventional-changelog-conventionalcommits": "8.0.0"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -94,5 +94,6 @@
   },
   "overrides": {
     "conventional-changelog-conventionalcommits": "8.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/hooks/useBoundingClientRect.ts
+++ b/src/hooks/useBoundingClientRect.ts
@@ -57,7 +57,7 @@ export function useBoundingClientRect(
 
     // @ts-ignore 👉 https://github.com/facebook/react/commit/53b1f69ba
     if (ref.current.unstable_getBoundingClientRect != null) {
-      // @ts-expect-error https://github.com/facebook/react/commit/53b1f69ba
+      // @ts-ignore https://github.com/facebook/react/commit/53b1f69ba
       const layout = ref.current.unstable_getBoundingClientRect();
       handler(layout);
       return;
@@ -65,7 +65,7 @@ export function useBoundingClientRect(
 
     // @ts-ignore once it `unstable_getBoundingClientRect` gets stable 🤞.
     if (ref.current.getBoundingClientRect != null) {
-      // @ts-expect-error once it `unstable_getBoundingClientRect` gets stable.
+      // @ts-ignore once it `unstable_getBoundingClientRect` gets stable.
       const layout = ref.current.getBoundingClientRect();
       handler(layout);
     }

--- a/src/hooks/useBoundingClientRect.ts
+++ b/src/hooks/useBoundingClientRect.ts
@@ -55,17 +55,17 @@ export function useBoundingClientRect(
       return;
     }
 
-    // @ts-ignore 👉 https://github.com/facebook/react/commit/53b1f69ba
-    if (ref.current.unstable_getBoundingClientRect !== null) {
-      // @ts-ignore https://github.com/facebook/react/commit/53b1f69ba
+    // @ts-expect-error 👉 https://github.com/facebook/react/commit/53b1f69ba
+    if (ref.current.unstable_getBoundingClientRect != null) {
+      // @ts-expect-error https://github.com/facebook/react/commit/53b1f69ba
       const layout = ref.current.unstable_getBoundingClientRect();
       handler(layout);
       return;
     }
 
-    // @ts-ignore once it `unstable_getBoundingClientRect` gets stable 🤞.
-    if (ref.current.getBoundingClientRect !== null) {
-      // @ts-ignore once it `unstable_getBoundingClientRect` gets stable.
+    // @ts-expect-error once it `unstable_getBoundingClientRect` gets stable 🤞.
+    if (ref.current.getBoundingClientRect != null) {
+      // @ts-expect-error once it `unstable_getBoundingClientRect` gets stable.
       const layout = ref.current.getBoundingClientRect();
       handler(layout);
     }

--- a/src/hooks/useBoundingClientRect.ts
+++ b/src/hooks/useBoundingClientRect.ts
@@ -55,7 +55,7 @@ export function useBoundingClientRect(
       return;
     }
 
-    // @ts-expect-error 👉 https://github.com/facebook/react/commit/53b1f69ba
+    // @ts-ignore 👉 https://github.com/facebook/react/commit/53b1f69ba
     if (ref.current.unstable_getBoundingClientRect != null) {
       // @ts-expect-error https://github.com/facebook/react/commit/53b1f69ba
       const layout = ref.current.unstable_getBoundingClientRect();
@@ -63,7 +63,7 @@ export function useBoundingClientRect(
       return;
     }
 
-    // @ts-expect-error once it `unstable_getBoundingClientRect` gets stable 🤞.
+    // @ts-ignore once it `unstable_getBoundingClientRect` gets stable 🤞.
     if (ref.current.getBoundingClientRect != null) {
       // @ts-expect-error once it `unstable_getBoundingClientRect` gets stable.
       const layout = ref.current.getBoundingClientRect();


### PR DESCRIPTION
Fix #2494 because `!== null` not checking if undefined
I have the same error after updating to RN0.82.0-rc4

