### PR TITLE
fix: avoid closing two modals at once

### DIFF
--- a/src/components/bottomSheetModalProvider/BottomSheetModalProvider.tsx
+++ b/src/components/bottomSheetModalProvider/BottomSheetModalProvider.tsx
@@ -102,8 +102,10 @@ const BottomSheetModalProviderWrapper = ({
      * Here we remove the unmounted sheet and update
      * the sheets queue.
      */
-    _sheetsQueue.splice(sheetIndex, 1);
-    sheetsQueueRef.current = _sheetsQueue;
+    if (sheetIndex !== -1) {
+      _sheetsQueue.splice(sheetIndex, 1);
+      sheetsQueueRef.current = _sheetsQueue;
+    }
 
     /**
      * Here we try to restore previous sheet position if unmounted


### PR DESCRIPTION
My app uses multiple modal bottom sheets. I had an intermittent case where with two modals in the queue, I closed the second one, and the first would not reappear. 

Upon debugging, I found the second modal had been removed as expected, but when the below code ran, the sheetIndex was -1. This caused the code to remove the first modal as well.

I don't remember specifically what caused the sheetIndex to be -1. Again, this was very intermittent.

In any case, preventing the splice from occurring when the sheetIndex = -1 is consistent with similar logic elsewhere in the code file.