### PR TITLE
fix: restore bottom sheet when keyboard is dismissed

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -659,7 +659,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           status === KEYBOARD_STATUS.SHOWN &&
           position !== closedDetentPosition
         ) {
-          index = highestDetentPosition ?? DEFAULT_KEYBOARD_INDEX;
+          index = detents?.indexOf(highestDetentPosition ?? 0) ?? DEFAULT_KEYBOARD_INDEX;
         }
 
         /**


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

This PR fixes a bug where the bottom sheet could assign a raw position value to index when the keyboard was shown. This caused animatedCurrentIndex to be set to invalid values (e.g. `235`), which led to broken state and the sheet height not resetting when the keyboard was dismissed.

The fix ensures index is resolved against the detents array, falling back to DEFAULT_KEYBOARD_INDEX if no match is found.

Solves:
#2509 
#2465 
#2460 