### PR TITLE
Fix EasingFunction type for reanimated 4

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,5 @@
 import { Dimensions, Platform } from 'react-native';
-import type Animated from 'react-native-reanimated';
-import { Easing } from 'react-native-reanimated';
+import { Easing, type EasingFunction } from 'react-native-reanimated';
 import type { SpringConfig, TimingConfig } from './types';
 
 const { height: WINDOW_HEIGHT, width: WINDOW_WIDTH } = Dimensions.get('window');
@@ -69,7 +68,7 @@ enum SNAP_POINT_TYPE {
   DYNAMIC = 1,
 }
 
-const ANIMATION_EASING: Animated.EasingFunction = Easing.out(Easing.exp);
+const ANIMATION_EASING: EasingFunction = Easing.out(Easing.exp);
 const ANIMATION_DURATION = 250;
 
 const ANIMATION_CONFIGS = Platform.select<TimingConfig | SpringConfig>({


### PR DESCRIPTION


## Motivation

We are seeing the following typescript error with reanimated 4:

```
node_modules/@gorhom/bottom-sheet/src/constants.ts:72:34 - error TS2694: Namespace '/node_modules/react-native-reanimated/lib/typescript/Animated"' has no exported member 'EasingFunction'.

72 const ANIMATION_EASING: Animated.EasingFunction = Easing.out(Easing.exp);
                                    ~~~~~~~~~~~~~~

Found 1 error in node_modules/@gorhom/bottom-sheet/src/constants.ts:72
```

This patch fixes the error by explicitly importing the type. 
