### PR TITLE
Drop doc line mentioning `stackBehavior` is only available in v3

### DIFF
--- a/website/docs/modal/props.md
+++ b/website/docs/modal/props.md
@@ -20,8 +20,6 @@ Modal name to help identify the modal for later on.
 
 ### stackBehavior
 
-**`Available only on v3, for now.`**
-
 Defines the stack behavior when modal mounts.
 
 - `push` it will mount the modal on top of the current one.


### PR DESCRIPTION
## Motivation

`stackBehavior` should be usable also in v5.

