### PR TITLE
fix: bottom sheet scroll jumpy

### DIFF
--- a/src/hooks/useGestureEventsHandlersDefault.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.tsx
@@ -382,8 +382,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
           translationY + context.value.initialPosition;
 
         if (wasGestureHandledByScrollView) {
-          rawDestinationPosition -=
-            animatedScrollableState.get().contentOffsetY;
+          rawDestinationPosition -= scrollableContentOffsetY;
         }
 
         /**

--- a/src/hooks/useGestureEventsHandlersDefault.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.tsx
@@ -375,11 +375,22 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
           snapPoints.unshift(closedDetentPosition);
         }
 
+        const wasGestureHandledByScrollView =
+          source === GESTURE_SOURCE.CONTENT && scrollableContentOffsetY > 0;
+
+        let rawDestinationPosition =
+          translationY + context.value.initialPosition;
+
+        if (wasGestureHandledByScrollView) {
+          rawDestinationPosition -=
+            animatedScrollableState.get().contentOffsetY;
+        }
+
         /**
          * calculate the destination point, using redash.
          */
         const destinationPoint = snapPoint(
-          translationY + context.value.initialPosition,
+          rawDestinationPosition,
           velocityY,
           snapPoints
         );
@@ -392,8 +403,6 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
           return;
         }
 
-        const wasGestureHandledByScrollView =
-          source === GESTURE_SOURCE.CONTENT && scrollableContentOffsetY > 0;
         /**
          * prevents snapping from top to middle / bottom with repeated interrupted scrolls
          */


### PR DESCRIPTION
## Motivation

When using BottomSheetScrollView, I ran into a strange issue.

During a long scroll, the pan gesture reads the same scroll distance. So when you try to scroll to the top, the bottom sheet mistakenly thinks you've already dragged it a long way. As a result, the sheet closes prematurely, which feels unintuitive.

## Solution

Simply take into account `scrollableContentOffsetY` during calculating `destinationPoint`

## Screenshots

### Close too soon

https://github.com/user-attachments/assets/ce41b0b3-1564-4419-afda-7525c5e09dfa

### Solution demo

https://github.com/user-attachments/assets/c8073f69-2604-400c-853d-5e515d6b2ac7

## Sidenote

- Change `map` to `forEach` since biome is complaining and failing the husky pipeline
