### PR TITLE
fix: fixed function undefined error in useBoundingClientRect

### DIFF
--- a/src/hooks/useBoundingClientRect.ts
+++ b/src/hooks/useBoundingClientRect.ts
@@ -55,17 +55,20 @@ export function useBoundingClientRect(
       return;
     }
 
-    // @ts-ignore 👉 https://github.com/facebook/react/commit/53b1f69ba
-    if (ref.current.unstable_getBoundingClientRect !== null) {
-      // @ts-ignore https://github.com/facebook/react/commit/53b1f69ba
+    // @ts-expect-error 👉 https://github.com/facebook/react/commit/53b1f69ba
+    if (
+      ref.current.unstable_getBoundingClientRect !== null &&
+      typeof ref.current.unstable_getBoundingClientRect === 'function'
+    ) {
+      // @ts-expect-error https://github.com/facebook/react/commit/53b1f69ba
       const layout = ref.current.unstable_getBoundingClientRect();
       handler(layout);
       return;
     }
 
-    // @ts-ignore once it `unstable_getBoundingClientRect` gets stable 🤞.
+    // @ts-expect-error once it `unstable_getBoundingClientRect` gets stable 🤞.
     if (ref.current.getBoundingClientRect !== null) {
-      // @ts-ignore once it `unstable_getBoundingClientRect` gets stable.
+      // @ts-expect-error once it `unstable_getBoundingClientRect` gets stable.
       const layout = ref.current.getBoundingClientRect();
       handler(layout);
     }


### PR DESCRIPTION
## Motivation

For some weird reason, this bug happens to bottom sheet when I load it on RN 0.82.1

This PR fixes the issue as detailed in this [link](https://github.com/gorhom/react-native-bottom-sheet/issues/2560)