### PR TITLE
Close visible modal on unmount

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -323,7 +323,7 @@ function BottomSheetModalComponent<T = any>(
       /**
        * if modal is already been dismiss, we exit the method.
        */
-      if (currentIndexRef.current === -1 && minimized.current === false) {
+      if (currentIndexRef.current === -1 && minimized.current === true) {
         return;
       }
 


### PR DESCRIPTION
## Motivation

Fixed a bug where the modal remained open after unmounting.

**Steps to reproduce the bug**
1. Open the modal
2. Unmount the component before the opening animation finishes

**Result**
The component is unmounted, the modal ref is null, but the modal is still visible and can only be closed by swiping down or tapping on the backdrop.

