### PR TITLE
Fix animatedPosition initialization logic

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -216,7 +216,11 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     const animatedCurrentIndex = useReactiveSharedValue(
       animateOnMount ? -1 : _providedIndex
     );
-    const animatedPosition = useSharedValue(INITIAL_POSITION);
+
+    const initialPosition = !animateOnMount
+      ? animatedDetentsState.get().detents?.[_providedIndex]
+      : undefined;
+    const animatedPosition = useSharedValue(initialPosition ?? INITIAL_POSITION);
 
     // conditional
     const isAnimatedOnMount = useSharedValue(


### PR DESCRIPTION
## Motivation

Tldr - fixing the issue described here:
https://github.com/gorhom/react-native-bottom-sheet/issues/2582

This initializes the `animatedPosition` with the right value if `animateOnMount` is disabled. 

This avoids two issues:
- Fixes issue with animation still playing if Layout is treated to be ready right away (e.g. no handle component and known size)
- Fixes first frame rendering in case when Layout is not ready (e.g. so the position is open right away rather than close -> open jump)
