### PR TITLE
fix(web): React 19 compatibility and type safety for findNodeHandle

### DIFF
--- a/src/utilities/findNodeHandle.web.ts
+++ b/src/utilities/findNodeHandle.web.ts
@@ -3,10 +3,29 @@ import {
   type NodeHandle,
 } from 'react-native';
 
+/**
+ * Type bridge for accessing undocumented React Native scroll component internals.
+ * These properties exist at runtime but aren't exposed in RN's public type definitions.
+ *
+ * @see https://github.com/facebook/react-native/blob/main/packages/virtualized-lists/Lists/VirtualizedList.js#L1252
+ */
+interface ScrollComponentInternals {
+  /** Available on ScrollView, FlatList, etc. to get the underlying native scroll ref */
+  getNativeScrollRef?: () => NodeHandle | null;
+  /** Internal property on VirtualizedList storing the scroll ref */
+  _scrollRef?: NodeHandle | null;
+}
+
 export function findNodeHandle(
   componentOrHandle: Parameters<typeof _findNodeHandle>['0']
-) {
-  let nodeHandle: NodeHandle | null;
+): NodeHandle | null | typeof componentOrHandle {
+  // Early return for null/undefined (React 19 fix)
+  if (componentOrHandle == null) {
+    return null;
+  }
+
+  let nodeHandle: NodeHandle | null = null;
+
   try {
     nodeHandle = _findNodeHandle(componentOrHandle);
     if (nodeHandle) {
@@ -14,18 +33,20 @@ export function findNodeHandle(
     }
   } catch {}
 
+  // Type bridge: componentOrHandle may have scroll internals at runtime
+  const scrollable = componentOrHandle as unknown as ScrollComponentInternals;
+
   try {
-    // @ts-expect-error
-    nodeHandle = componentOrHandle.getNativeScrollRef();
-    if (nodeHandle) {
-      return nodeHandle;
+    if (typeof scrollable.getNativeScrollRef === 'function') {
+      nodeHandle = scrollable.getNativeScrollRef();
+      if (nodeHandle) {
+        return nodeHandle;
+      }
     }
   } catch {}
 
-  // @ts-expect-error https://github.com/facebook/react-native/blob/a314e34d6ee875830d36e4df1789a897c7262056/packages/virtualized-lists/Lists/VirtualizedList.js#L1252
-  nodeHandle = componentOrHandle._scrollRef;
-  if (nodeHandle) {
-    return nodeHandle;
+  if (scrollable._scrollRef != null) {
+    return scrollable._scrollRef;
   }
 
   console.warn('could not find scrollable ref!');


### PR DESCRIPTION
## Summary

Fixes React 19 compatibility issue and improves type safety in the web `findNodeHandle` utility.

## Problem

### React 19 Crash (#2366)
React 19 removed `findHostInstance_DEPRECATED` and changed when `findNodeHandle` can return `null`. With Expo SDK 53+ and React 19, the function crashes when `componentOrHandle` is `null` or `undefined` during component lifecycle transitions (mount/unmount).

### Web Platform Crash (#2237)
On web, accessing `componentOrHandle.getNativeScrollRef()` or `componentOrHandle._scrollRef` without null checks can crash when the component is unmounted or during hot reload.

### Type Safety
The existing code used `@ts-ignore` to access undocumented React Native scroll component internals, hiding potential type errors.

## Solution

1. **Early null check** - Return `null` immediately if `componentOrHandle` is nullish, preventing crashes in React 19

2. **Proper TypeScript interface** - Replace `@ts-ignore` with a documented type bridge:
   ```typescript
   interface ScrollComponentInternals {
     getNativeScrollRef?: () => NodeHandle | null;
     _scrollRef?: NodeHandle | null;
   }
   ```

3. **Runtime type checking** - Use `typeof scrollable.getNativeScrollRef === 'function'` before calling, rather than relying on try/catch for flow control

4. **Explicit return type** - Add proper return type annotation for better type inference

## Related Issues

- Fixes #2366 (React 19 crash with Expo SDK 53)
- Fixes #2237 (Web platform crash)

## Testing

Tested with:
- React 19 + Expo SDK 53
- Web platform (React Native Web)
- Hot reload scenarios
