### PR TITLE
Fix: Screen rotation (from landscape to portait) causes bottom sheet to open 

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -895,8 +895,11 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
 
         /**
          * return the current index position.
+         * If index is -1 (closed), return closedDetentPosition instead of detents[-1]
          */
-        return detents[currentIndex];
+        return currentIndex === -1 
+          ? closedDetentPosition 
+          : detents[currentIndex];
       },
       [
         animatedContentGestureState,


### PR DESCRIPTION
[Bug: Screen rotation (from landscape to portait) causes bottom sheet to open](https://github.com/gorhom/react-native-bottom-sheet/issues/2585)

Fixed getEvaluatedPosition returning undefined when the bottom sheet is closed (currentIndex === -1).

**Problem**
When the sheet is closed, accessing detents[-1] returns undefined, which prevents the sheet from updating its position correctly during device rotation or when snap points change.

**Solution**
Added a check to return closedDetentPosition when currentIndex === -1, instead of accessing detents[-1].

**Testing**
Verified position updates correctly during device rotation when sheet is closed
Confirmed evaluatedPosition is no longer undefined when currentIndex === -1

