### PR TITLE
fix: react 19 typescript compatibility

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -465,7 +465,9 @@ function BottomSheetModalComponent<T = any>(
   ) : null;
 }
 
-const BottomSheetModal = memo(forwardRef(BottomSheetModalComponent)) as <
+const BottomSheetModal = memo(
+  forwardRef(BottomSheetModalComponent)
+) as unknown as <
   // biome-ignore lint/suspicious/noExplicitAny: Using 'any' allows users to define their own strict types for 'data' property.
   T = any,
 >(
@@ -474,7 +476,7 @@ const BottomSheetModal = memo(forwardRef(BottomSheetModalComponent)) as <
   }
 ) => ReturnType<typeof BottomSheetModalComponent>;
 (
-  BottomSheetModal as React.MemoExoticComponent<
+  BottomSheetModal as unknown as React.MemoExoticComponent<
     typeof BottomSheetModalComponent
   >
 ).displayName = 'BottomSheetModal';

--- a/src/hooks/useStableCallback.ts
+++ b/src/hooks/useStableCallback.ts
@@ -8,7 +8,7 @@ type Callback<T extends unknown[], R> = (...args: T) => R;
 export function useStableCallback<T extends unknown[], R>(
   callback: Callback<T, R>
 ) {
-  const callbackRef = useRef<Callback<T, R>>();
+  const callbackRef = useRef<Callback<T, R> | undefined>(undefined);
 
   useLayoutEffect(() => {
     callbackRef.current = callback;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,6 +18,7 @@ import type {
   State,
 } from 'react-native-gesture-handler';
 import type {
+  AnimatedRef,
   EasingFunction,
   EasingFunctionFactory,
   ReduceMotion,
@@ -30,7 +31,6 @@ import type {
   ANIMATION_STATUS,
   GESTURE_SOURCE,
   KEYBOARD_STATUS,
-  SCROLLABLE_STATUS,
   SCROLLABLE_TYPE,
 } from './constants';
 
@@ -226,7 +226,7 @@ type ScrollEventHandlerCallbackType<C = never> = (
 ) => void;
 
 export type ScrollEventsHandlersHookType = (
-  ref: React.RefObject<Scrollable>,
+  ref: AnimatedRef<Scrollable>,
   contentOffsetY: SharedValue<number>
 ) => {
   handleOnScroll?: ScrollEventHandlerCallbackType;


### PR DESCRIPTION
## Summary                                                                    
                                                                                
  Fixes TypeScript errors when using the library with React 19 and strict type  
  checking.                                                                     
                                                                                
  Closes #2363                                                                  
                                                                                
  ## Changes                                                                    
                                                                                
  ### 1. `src/hooks/useStableCallback.ts`                                       
  React 19 requires `useRef()` to have an initial value.                        
                                                                                
  ### 2. `src/types.d.ts`                                                       
  `useAnimatedRef()` returns `AnimatedRef<T>`, not `RefObject<T>`. Updated      
  `ScrollEventsHandlersHookType` to use the correct type.                       
                                                                                
### 3. `src/components/bottomSheetModal/BottomSheetModal.tsx`                 
  The generic `forwardRef` + `memo` pattern requires casting through `unknown`  
  with React 19's stricter types. This is a known TypeScript limitation where   
  generics are lost when wrapping components with `forwardRef` and `memo` 
                                                                                
  **Note:** This cast is a temporary workaround. Per the [React 19 release notes](https://react.dev/blog/2024/12/05/react-19), `forwardRef` will be deprecated in future versions in favor of passing `ref` as a regular prop. Once this library migrates away from `forwardRef`, this cast can be simplified or removed entirely.                                                    
                                                                                
  ## Testing                                                                    
                                                                                
  Verified with `tsc --noEmit` on a project using:                              
  - React Native 0.79                                                           
  - React 19                                                                    
  - TypeScript 5.x with strict mode                                             
                           