### PR TITLE
docs: useBottomSheetScrollableCreator example

### DIFF
--- a/website/docs/hooks.md
+++ b/website/docs/hooks.md
@@ -103,7 +103,7 @@ const SheetContent = () => {
     <BottomSheet>
       <LegendList
         {...}
-        renderScrollComponent={BottomSheetLegendListScrollable}
+        renderScrollComponent={BottomSheetScrollable}
       />
     </BottomSheet>
   )


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

The documentation example has a variable name mismatch: BottomSheetScrollable is created but BottomSheetLegendListScrollable is referenced in renderScrollComponent, causing an undefined reference error. This fix corrects the variable name so the example actually works.