### PR TITLE
Docs: Fix typo and improve variable naming in hooks.md

### DIFF
--- a/website/docs/hooks.md
+++ b/website/docs/hooks.md
@@ -90,7 +90,7 @@ const SheetContent = () => {
 
 ## useBottomSheetScrollableCreator
 
-A custom hook that creates a scrollable component for third-party libraries like `LegendList` or `FlashList` to integrate the interaction and scrolling behaviors with th BottomSheet component.
+A custom hook that creates a scrollable component for third-party libraries like `LegendList` or `FlashList` to integrate the interaction and scrolling behaviors with the BottomSheet component.
 
 ```tsx
 import React from 'react';
@@ -98,7 +98,7 @@ import BottomSheet, { useBottomSheetScrollableCreator } from '@gorhom/bottom-she
 import { LegendList } from '@legendapp/list';
 
 const SheetContent = () => {
-  const BottomSheetScrollable = useBottomSheetScrollableCreator();
+  const BottomSheetLegendListScrollable = useBottomSheetScrollableCreator();
   return (
     <BottomSheet>
       <LegendList


### PR DESCRIPTION
This pull request makes a minor update to the documentation for the `useBottomSheetScrollableCreator` hook. The main change is renaming a variable in the example code for improved clarity.

- Documentation update:
  * In the `website/docs/hooks.md` file, the example variable name was changed from `BottomSheetScrollable` to `BottomSheetLegendListScrollable` to better reflect its usage.