### PR TITLE
fix: add typeof guard for getBoundingClientRect in useBoundingClientRect

### DIFF
--- a/src/hooks/useBoundingClientRect.ts
+++ b/src/hooks/useBoundingClientRect.ts
@@ -67,8 +67,12 @@ export function useBoundingClientRect(
       return;
     }
 
-    // @ts-expect-error once it `unstable_getBoundingClientRect` gets stable 🤞.
-    if (ref.current.getBoundingClientRect !== null) {
+    if (
+      // @ts-expect-error once it `unstable_getBoundingClientRect` gets stable 🤞.
+      ref.current.getBoundingClientRect !== null &&
+      // @ts-expect-error once it `unstable_getBoundingClientRect` gets stable 🤞.
+      typeof ref.current.getBoundingClientRect === 'function'
+    ) {
       // @ts-expect-error once it `unstable_getBoundingClientRect` gets stable.
       const layout = ref.current.getBoundingClientRect();
       handler(layout);


### PR DESCRIPTION
PR #2561 fixed the `unstable_getBoundingClientRect` path (line 58) by adding a `typeof === 'function'` guard, but the fallback `getBoundingClientRect` path (line 71) was missed, it still only checks `!== null`.

In `react-test-renderer`, `nativeFabricUIManager` is set to `{}` by React Native's jest setup (`react-native/jest/setup.js` line 36), which makes `isFabricInstalled()` return `true`. This causes the `useBoundingClientRect` hook to execute the Fabric code path. Since `getBoundingClientRect` is `undefined` (not `null`) on test renderer refs, the `!== null` check passes and the call crashes:

```
TypeError: ref.current.getBoundingClientRect is not a function at useBoundingClientRect.ts:73:34
```

This affects any jest test that renders a `BottomSheet` component deeply enough to trigger the hook.

Fixes #2625
Reproduction: https://github.com/magrinj/bottom-sheet-test-bug