### PR TITLE
fix: invoke render function children instead of rendering as JSX component

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -458,7 +458,7 @@ function BottomSheetModalComponent<T = any>(
           onAnimate={handleBottomSheetOnAnimate}
           $modal={true}
         >
-          {typeof Content === 'function' ? <Content data={data} /> : Content}
+          {typeof Content === 'function' ? Content({ data }) : Content}
         </BottomSheet>
       </ContainerComponent>
     </Portal>


### PR DESCRIPTION
## Summary

This reverts the regression introduced during the v5 migration, where `Content({ data })` was changed back to `<Content data={data} />`.

This fix was originally introduced in #1750 but was lost during the v5 codebase migration.

## Problem

As `data` is an object, rendering `<Content data={data} />` creates unnecessary re-renders due to unstable function references. Invoking `Content({ data })` directly avoids this issue.

## Solution

```diff
- {typeof Content === 'function' ? <Content data={data} /> : Content}
+ {typeof Content === 'function' ? Content({ data }) : Content}
```