### PR TITLE
fix(bottomsheet): fix an issue that results in a collapsed bottomshee…

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1552,12 +1552,32 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           nextIndex === -1
         ) {
           animateToPosition(closedDetentPosition, ANIMATION_SOURCE.GESTURE);
+          return;
+        }
+
+        /**
+         * When the container resizes (e.g. window resize on web, or layout
+         * changes) while the sheet is closed, ensure the closed position stays
+         * in sync. Without this, the sheet can become partially visible if
+         * the container grows beyond the previous closed position — for
+         * example when the browser viewport expands due to zoom level or
+         * window resize.
+         */
+        if (
+          animationStatus !== ANIMATION_STATUS.RUNNING &&
+          animatedCurrentIndex.value === -1 &&
+          animatedPosition.value < closedDetentPosition
+        ) {
+          setToPosition(closedDetentPosition);
         }
       },
       [
         animatedContainerHeightDidChange,
         animatedAnimationState,
         animatedDetentsState,
+        animatedCurrentIndex,
+        animatedPosition,
+        setToPosition,
       ]
     );
 

--- a/src/components/bottomSheet/constants.ts
+++ b/src/components/bottomSheet/constants.ts
@@ -3,6 +3,7 @@ import {
   KEYBOARD_BLUR_BEHAVIOR,
   KEYBOARD_INPUT_MODE,
   SCREEN_HEIGHT,
+  WINDOW_HEIGHT,
 } from '../../constants';
 
 // default values
@@ -25,7 +26,7 @@ const DEFAULT_KEYBOARD_INDEX = -998;
 // initial values
 const INITIAL_VALUE = Number.NEGATIVE_INFINITY;
 const INITIAL_SNAP_POINT = -999;
-const INITIAL_POSITION = SCREEN_HEIGHT;
+const INITIAL_POSITION = Math.max(SCREEN_HEIGHT, WINDOW_HEIGHT);
 
 // accessibility
 const DEFAULT_ACCESSIBLE = true;


### PR DESCRIPTION
…t from being visible

in chrome a collapsed bottom sheet will be visible under certain circumstances when the user is zoomed out due to in incorrectly calculated closed position. this issue is more prominent during window resizes while zoomed out.

fix #2639

Please provide enough information so that others can review your pull request:

## Motivation

This issue solves https://github.com/gorhom/react-native-bottom-sheet/issues/2639

