### PR TITLE
fix(layout): correct isLayoutCalculated always returning true

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -225,12 +225,12 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     const isLayoutCalculated = useDerivedValue(() => {
       let isContainerHeightCalculated = false;
       const { containerHeight, handleHeight } = animatedLayoutState.get();
-      //container height was provided.
-      if (containerHeight !== null && containerHeight !== undefined) {
-        isContainerHeightCalculated = true;
-      }
-      // container height did set.
-      if (containerHeight !== INITIAL_LAYOUT_VALUE) {
+      //container height was provided and set not to initial value
+      if (
+        containerHeight !== null &&
+        containerHeight !== undefined &&
+        containerHeight !== INITIAL_LAYOUT_VALUE
+      ) {
         isContainerHeightCalculated = true;
       }
 

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -226,7 +226,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
       let isContainerHeightCalculated = false;
       const { containerHeight, handleHeight } = animatedLayoutState.get();
       //container height was provided.
-      if (containerHeight !== null || containerHeight !== undefined) {
+      if (containerHeight !== null && containerHeight !== undefined) {
         isContainerHeightCalculated = true;
       }
       // container height did set.


### PR DESCRIPTION
## Summary

`isLayoutCalculated` in `BottomSheet.tsx` line 229 uses `||` (OR) instead of `&&` (AND) when checking whether `containerHeight` has been provided:

```typescript
// Current (always true)
if (containerHeight !== null || containerHeight !== undefined) {

// Fixed
if (containerHeight !== null && containerHeight !== undefined) {
```

`x !== null || x !== undefined` is a tautology — it evaluates to `true` for every possible value. This means `isContainerHeightCalculated` is always set to `true` on line 230, regardless of the actual container height state.

## Impact

While the second guard (`containerHeight !== INITIAL_LAYOUT_VALUE`) usually catches this, the logical error means `isLayoutCalculated` can return `true` before layout measurements complete if `containerHeight` happens to be `null` or `undefined` rather than `INITIAL_LAYOUT_VALUE`. This allows `evaluatePosition` to run prematurely, potentially producing incorrect detent positions.

We observed a production issue where the bottom sheet's backdrop rendered correctly but the content panel was positioned off-screen (invisible), with `onChange(index >= 0)` still firing — leaving users stuck behind a non-dismissable backdrop. The premature layout calculation is a plausible contributing factor.

## Change

Single character: `||` → `&&` on line 229 of `src/components/bottomSheet/BottomSheet.tsx`.