### PR TITLE
fix: bottom sheet not appearing with android reduce motion

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useState,
 } from 'react';
 import { Dimensions, Platform, StyleSheet } from 'react-native';
 import { State } from 'react-native-gesture-handler';
@@ -279,6 +280,13 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         ? userReduceMotionSetting
         : _providedOverrideReduceMotion === ReduceMotion.Always;
     }, [userReduceMotionSetting, _providedOverrideReduceMotion]);
+
+    const [, _forceUpdate] = useState(0);
+    const handleReduceMotionMountFlush = useCallback(() => {
+      if (Platform.OS === 'android' && reduceMotion) {
+        _forceUpdate((prev: number) => prev + 1);
+      }
+    }, [reduceMotion]);
     //#endregion
 
     //#region state/dynamic variables
@@ -977,7 +985,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
            * if animate on mount is set to true, then we animate to the propose position,
            * else, we set the position with out animation.
            */
-          if (animateOnMount) {
+          if (animateOnMount && !(Platform.OS === 'android' && reduceMotion)) {
             animateToPosition(
               proposedPosition,
               ANIMATION_SOURCE.MOUNT,
@@ -987,6 +995,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           } else {
             setToPosition(proposedPosition);
             didAnimateOnMount.value = true;
+            runOnJS(handleReduceMotionMountFlush)();
           }
           return;
         }
@@ -1077,6 +1086,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         didAnimateOnMount,
         isInTemporaryPosition,
         isLayoutCalculated,
+        handleReduceMotionMountFlush,
       ]
     );
     //#endregion


### PR DESCRIPTION
## Motivation

This fixes bottom sheets not appearing when Android has reduce motion on, without disabling the reduced motion for users who have opted in.

As opposed to the approach in https://github.com/gorhom/react-native-bottom-sheet/pull/1743, which forces the setting off in certain circumstances, this PR would trigger one more rerender on the `BottomSheet` component to force the screen to commit the changes.

I traced through the source code of `@gorhom/bottom-sheet` and `react-native-reanimated` (I'm on verison 3.19, but I imagine the core mechanism is the same across v4). I believe I've pieced together the root cause of the issue, and a simple (albeit kind of clunky) fix.

With reduce motion enabled and `animateOnMount=true` (the default), the `BottomSheet` component calls `animateToPosition`. [Source](https://github.com/gorhom/react-native-bottom-sheet/blob/0a0a06027c6405d3f767ee1adaa2dd668b553c9e/src/components/bottomSheet/BottomSheet.tsx#L974-L984)

```tsx
if (animateOnMount) {
  animateToPosition(
    proposedPosition,
    ANIMATION_SOURCE.MOUNT,
    undefined,
    animationConfigs,
  );
} else {
  setToPosition(proposedPosition);
  isAnimatedOnMount.value = true;
}
```

`animateToPosition` calls `animate` from [utilities](https://github.com/gorhom/react-native-bottom-sheet/blob/0a0a06027c6405d3f767ee1adaa2dd668b553c9e/src/components/bottomSheet/BottomSheet.tsx#L692-L698):

```tsx
animatedPosition.value = animate({
  point: position,
  configs: configs || _providedAnimationConfigs,
  velocity,
  overrideReduceMotion: _providedOverrideReduceMotion,
  onComplete: animateToPositionCompleted,
});
```

Which in turn calls `withTiming` or `withSpring` [here](https://github.com/gorhom/react-native-bottom-sheet/blob/0a0a06027c6405d3f767ee1adaa2dd668b553c9e/src/utilities/animate.ts#L47-L55):

```tsx
if (type === ANIMATION_METHOD.TIMING) {
  return withTiming(point, configs as WithTimingConfig, onComplete);
}

return withSpring(
  point,
  Object.assign({ velocity }, configs) as WithSpringConfig,
  onComplete,
);
```

`withSpring`/`withTiming` return an `AnimationObject` — an object with an `onFrame` method. Reanimated's shared value has a [custom setter](https://github.com/software-mansion/react-native-reanimated/blob/3.19.2/src/valueSetter.ts) that intercepts every assignment and branches on this:

```tsx
// valueSetter.ts
if (
  typeof value === 'function' ||
  (value !== null &&
    typeof value === 'object' &&
    (value as unknown as AnimationObject).onFrame !== undefined) // AnimationObject check
) {
  // animation path — initialize and run the first frame
  initializeAnimation(currentTimestamp); // calls animation.onStart(...)

  const step = (newTimestamp: number) => {
    const finished = animation.onFrame(animation, timestamp);
    mutable._value = animation.current!;
    if (finished) {
      animation.callback && animation.callback(true);
    } else {
      requestAnimationFrame(step); // line 72 — schedules next frame
    }
  };

  step(currentTimestamp); // called synchronously
} else {
  // direct assignment path
  mutable._value = value; // line 85
}
```

Inside `initializeAnimation`, reanimated calls `animation.onStart`. Reanimated wraps every animation's `onStart` with a reduce-motion check [in `animation/util.ts`](https://github.com/software-mansion/react-native-reanimated/blob/31bfe931111a137ffc5f93224d522148af23d0f6/packages/react-native-reanimated/src/animation/util.ts#L490-L503):

```ts
// animation/util.ts — called during initializeAnimation
if (animation.reduceMotion === undefined) {
  animation.reduceMotion = getReduceMotionFromConfig(); // reads system setting → true
}
if (animation.reduceMotion) {
  animation.current = animation.toValue; // jump to target value immediately
  animation.startTime = 0;
  animation.onFrame = () => true; // ← replace onFrame with one that always returns finished
  return;
}
```

When reduce motion is active, `onStart` replaces `onFrame` with `() => true` and pre-sets `animation.current` to the target value before `step` ever runs. Back in `valueSetter`, `step(currentTimestamp)` is then called synchronously:

```ts
const step = (newTimestamp: number) => {
  const finished = animation.onFrame(animation, timestamp); // → () => true → finished immediately
  mutable._value = animation.current!; // direct assignment to target
  if (finished) {
    animation.callback && animation.callback(true);
    // requestAnimationFrame is never reached
  } else {
    requestAnimationFrame(step); // ← NEVER REACHED
  }
};

step(currentTimestamp); // synchronous, finishes in one call
```

`animateToPosition` under reduce motion ends up with no `requestAnimationFrame` call. From here, the Choreographer chain that would flush native view updates is never entered.

## Why This Breaks Android

`requestAnimationFrame` in a Reanimated worklet is an [override installed on the UI thread by Reanimated during initialization](https://github.com/software-mansion/react-native-reanimated/blob/31bfe931111a137ffc5f93224d522148af23d0f6/packages/react-native-reanimated/src/initializers.ts#L166-L178):

```ts
// initializers.ts
global.requestAnimationFrame = (
  callback: (timestamp: number) => void,
): number => {
  animationFrameCallbacks.push(callback);
  if (!flushRequested) {
    flushRequested = true;
    // nativeRequestAnimationFrame is the next important call in the diagnosis
    nativeRequestAnimationFrame((timestamp) => {
      flushRequested = false;
      global.__flushAnimationFrame(timestamp);
    });
  }
  return -1;
};
```

`nativeRequestAnimationFrame` is a [JSI binding that calls into Reanimated's C++ layer](https://github.com/software-mansion/react-native-reanimated/blob/31bfe931111a137ffc5f93224d522148af23d0f6/packages/react-native-reanimated/Common/cpp/reanimated/NativeModules/ReanimatedModuleProxy.cpp#L574-L586):

```cpp
// ReanimatedModuleProxy.cpp
void ReanimatedModuleProxy::requestAnimationFrame(
    jsi::Runtime &rt,
    const jsi::Value &callback) {
  frameCallbacks_.push_back(std::make_shared<jsi::Value>(rt, callback));
  maybeRequestRender(); // line 578
}

void ReanimatedModuleProxy::maybeRequestRender() {
  if (!renderRequested_) {
    renderRequested_ = true;
    requestRender_(onRenderCallback_); // line 584 calls into Java
  }
}
```

`requestRender_` is a [function pointer bound to the Java side](https://github.com/software-mansion/react-native-reanimated/blob/31bfe931111a137ffc5f93224d522148af23d0f6/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/nativeProxy/NativeProxyCommon.java#L91-L93):

```java
// NativeProxyCommon.java
@DoNotStrip
public void requestRender(AnimationFrameCallback callback) {
  mNodesManager.postOnAnimation(callback); // line 92
}
```

`postOnAnimation` queues the callback and calls `startUpdatingOnAnimationFrame`, which [registers a callback with Android's `ReactChoreographer`](https://github.com/software-mansion/react-native-reanimated/blob/31bfe931111a137ffc5f93224d522148af23d0f6/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java#L340-L342):

```java
// NodesManager.java
public void postOnAnimation(OnAnimationFrame onAnimationFrame) {
  mFrameCallbacks.add(onAnimationFrame);
  startUpdatingOnAnimationFrame(); // line 342
}

public void startUpdatingOnAnimationFrame() {
  if (!mCallbackPosted.getAndSet(true)) {
    mReactChoreographer.postFrameCallback(
        ReactChoreographer.CallbackType.NATIVE_ANIMATED_MODULE,
        mChoreographerCallback); // line 227-228
  }
}
```

The [Android `Choreographer`](https://developer.android.com/reference/android/view/Choreographer) is the system class responsible for coordinating all drawing on the main thread. It fires registered callbacks in sync with the display's vsync signal. Only work that runs inside a Choreographer callback is guaranteed to be committed to the screen in the next frame.

When `mReactChoreographer.postFrameCallback` is called, Android schedules `onAnimationFrame` to [run at the next vsync](https://github.com/software-mansion/react-native-reanimated/blob/31bfe931111a137ffc5f93224d522148af23d0f6/packages/react-native-reanimated/android/src/main/java/com/swmansion/reanimated/NodesManager.java#L287-L325). That callback evaluates all `useAnimatedStyle` hooks that depend on changed shared values and commits the resulting style updates to native views.

Because reduce motion causes `step()` to return `finished=true` on its first synchronous call, `requestAnimationFrame` is never invoked. The entire chain of `nativeRequestAnimationFrame` → `maybeRequestRender` → `postOnAnimation` → `postFrameCallback` is never entered. The Choreographer is never notified, `useAnimatedStyle` is never re-evaluated, and the native view is never updated, even though `BottomSheet` believes it has completed its mount animation.

Perhaps we should submit this to reanimated itself, but the bottom sheet library can workaround the problem by directly setting the value and flushing the animation.

