### PR TITLE
fix: prevent rapid present/close from freezing BottomSheetModal

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -968,6 +968,13 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          */
         if (!isAnimatedOnMount.value) {
           /**
+           * if there's a running animation (like force close), respect it and don't
+           * override with mount animation
+           */
+          if (animationStatus === ANIMATION_STATUS.RUNNING) {
+            return;
+          }
+          /**
            * if animate on mount is set to true, then we animate to the propose position,
            * else, we set the position with out animation.
            */

--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -189,6 +189,10 @@ function BottomSheetModalComponent<T = never>(
   const handlePresent = useCallback(
     function handlePresent(_data?: T) {
       requestAnimationFrame(() => {
+        if (mounted.current && bottomSheetRef.current) {
+          forcedDismissed.current = false;
+          bottomSheetRef.current.snapToIndex(index);
+        }
         setState({
           mount: true,
           data: _data,
@@ -209,7 +213,7 @@ function BottomSheetModalComponent<T = never>(
       });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [key, stackBehavior, mountSheet]
+    [key, stackBehavior, mountSheet, index]
   );
   const handleDismiss = useCallback<BottomSheetModalMethods['dismiss']>(
     function handleDismiss(animationConfigs) {


### PR DESCRIPTION
## Motivation

`BottomSheetModal` freezes when you call `present()` and `close()` rapidly through a state-driven `useEffect`:

```tsx
const [open, setOpen] = useState(false);
const bottomSheetRef = useRef<BottomSheetModal>(null);

useEffect(() => {
  if (open) {
    bottomSheetRef.current?.present();
  } else {
    bottomSheetRef.current?.close();
  }
}, [open]);

// setOpen(true) → setOpen(false) → setOpen(true) rapidly → modal gets stuck and can't be closed
```

**Expected:** Modal closes and re-opens properly.
**Actual:** Modal stays open and is frozen, can't be closed anymore.

**Root cause:**

There are two issues:

1. In `BottomSheet.tsx`, `evaluatePosition` calls `animateToPosition` for the mount animation without checking if a close animation is already running. The mount animation overrides the close and the sheet gets stuck.

2. In `BottomSheetModal.tsx`, `handlePresent` calling `present()` while the sheet is still mounted but closing does nothing because `setState({ mount: true })` won't re-render when `mount` is already `true`. So the close animation just finishes, `onClose` fires, and the modal gets unmounted even though `present()` was just called.

**Fix:**

1. Skip mount animation when `animationStatus === ANIMATION_STATUS.RUNNING`.
2. When `present()` is called on an already-mounted sheet, call `snapToIndex(index)` to interrupt the close and re-open it.

Also worth mentioning that consumers should always sync their state back in `onDismiss` when using a controlled bottom sheet.

Supersedes #2529.
