### PR TITLE
fix: sanitize velocity to prevent instant snap on Reanimated v4+

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -687,12 +687,43 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         runOnJS(handleOnAnimate)(index, position);
 
         /**
+         * Sanitize velocity before passing it to the spring animation.
+         *
+         * Reanimated v4 + Gesture Handler v2 can report an excessively high
+         * velocity whose direction is *opposite* to the snap target. When
+         * that velocity is fed straight into `withSpring` the animation
+         * resolves almost instantly (the spring overshoots and settles in a
+         * single frame), giving the appearance of no animation at all.
+         *
+         * To fix this we:
+         *  1. Clamp the absolute velocity so springs stay smooth even on
+         *     very fast flings.
+         *  2. Zero the velocity when it points away from the target so the
+         *     spring never fights the snap direction.
+         *
+         * These guards are safe for all Reanimated versions – large
+         * opposing velocities are never desirable for a snap animation.
+         *
+         * @see https://github.com/gorhom/react-native-bottom-sheet/issues/2470
+         */
+        const MAX_VELOCITY = 500;
+        const clampedVelocity = Math.max(
+          -MAX_VELOCITY,
+          Math.min(MAX_VELOCITY, velocity)
+        );
+        const currentPosition = animatedPosition.value;
+        const movingTowardsTarget =
+          (position > currentPosition && clampedVelocity > 0) ||
+          (position < currentPosition && clampedVelocity < 0);
+        const effectiveVelocity = movingTowardsTarget ? clampedVelocity : 0;
+
+        /**
          * start animation
          */
         animatedPosition.value = animate({
           point: position,
           configs: configs || _providedAnimationConfigs,
-          velocity,
+          velocity: effectiveVelocity,
           overrideReduceMotion: _providedOverrideReduceMotion,
           onComplete: animateToPositionCompleted,
         });


### PR DESCRIPTION
## Summary

Fixes #2470 — no smooth animation when the bottom sheet snaps back to its initial position on **Reanimated v4 + Gesture Handler v2**.

## Root Cause

Reanimated v4 + Gesture Handler v2 can report an excessively high `velocityY` whose direction is **opposite** to the snap target. When this velocity is passed directly to `withSpring`, the spring overshoots and resolves in a single frame — producing an instant snap with no visible animation.

## Fix

Two guards are applied to the velocity inside `animateToPosition` before it reaches `withSpring`:

1. **Clamp** the absolute velocity to ±500 — prevents absurdly high values from producing jarring or invisible animations.
2. **Zero** the velocity when it opposes the snap direction — if the sheet needs to snap up but velocity points down (or vice versa), velocity is set to 0 so the spring does not fight the target.

## Why this is safe for all Reanimated versions

- The guards live in `animateToPosition`, the single entry point for all snap animations.
- Large opposing velocities are never desirable for a snap animation regardless of Reanimated version.
- On Reanimated v2/v3 where velocity is correctly reported, it is typically already aligned with the snap direction (passes through unchanged) or small enough to be within the 500 cap.
- Programmatic calls (no gesture) pass `velocity = 0` by default and are completely unaffected.

## Related

- Issue: #2470
- Community-validated patch by @jluisrojas confirming this approach resolves the bug.
- Confirmed across iOS with Reanimated v4 + Gesture Handler v2 + Expo 54.