### PR TITLE
fix: crash ui after opening BottomSheetModal with BottomSheetSectionList on Web 5.2.10 (#2662)

### DIFF
--- a/src/utilities/findNodeHandle.web.ts
+++ b/src/utilities/findNodeHandle.web.ts
@@ -12,6 +12,7 @@ import {
 interface ScrollComponentInternals {
   /** Available on ScrollView, FlatList, etc. to get the underlying native scroll ref */
   getNativeScrollRef?: () => NodeHandle | null;
+  getScrollableNode?: () => NodeHandle | null;
   /** Internal property on VirtualizedList storing the scroll ref */
   _scrollRef?: NodeHandle | null;
 }
@@ -39,6 +40,15 @@ export function findNodeHandle(
   try {
     if (typeof scrollable.getNativeScrollRef === 'function') {
       nodeHandle = scrollable.getNativeScrollRef();
+      if (nodeHandle) {
+        return nodeHandle;
+      }
+    }
+  } catch {}
+
+  try {
+    if (typeof scrollable.getScrollableNode === 'function') {
+      nodeHandle = scrollable.getScrollableNode();
       if (nodeHandle) {
         return nodeHandle;
       }


### PR DESCRIPTION
fix: #2662

It turns out that `SectionList` doesn't have a `getNativeScrollRef` method, but it does have a `getScrollableNode` method. This solves the issue I referenced above.

I'm actually not sure whether any changes are needed on this library's side. This seems more like a `react-native-web` bug, but I don't quite understand why this method wasn't added. One related old [issue](https://github.com/necolas/react-native-web/issues/1560). There may be some reasoning behind this that I'm not aware of.

I would appreciate any feedback. If needed, I can refine these changes or open an issue/PR in the `react-native-web` library.