### PR TITLE
fix(modal): restore React mount state reset in unmount() after #2632

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -64,6 +64,8 @@ function BottomSheetModalComponent<T = never>(
   //#region state
   const [{ mount, data }, setState] =
     useState<BottomSheetModalState<T>>(INITIAL_STATE);
+  const mountRef = useRef(mount);
+  mountRef.current = mount;
   //#endregion
 
   //#region hooks
@@ -109,6 +111,8 @@ function BottomSheetModalComponent<T = never>(
           method: unmount.name,
         });
       }
+      const hadReactMount = mountRef.current;
+
       // reset variables
       resetVariables();
 
@@ -116,12 +120,8 @@ function BottomSheetModalComponent<T = never>(
       unmountSheet(key);
       unmountPortal(key);
 
-      // unmount the node, if sheet is still mounted
-      if (
-        [MODAL_STATUS.PRESENTED, MODAL_STATUS.ANIMATING].includes(
-          statusRef.current
-        )
-      ) {
+      // unmount the node, if sheet is still mounted in React state
+      if (hadReactMount) {
         setState(INITIAL_STATE);
       }
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced in **v5.2.11** with [#2632](https://github.com/gorhom/react-native-bottom-sheet/issues/2632) (modal status refactor): after dismissing a `BottomSheetModal`, React state could keep `mount: true`, so a later `present()` (e.g. from `useFocusEffect` when navigating) would hit the fast path and call `snapToIndex(index)`—closed sheets appeared to reopen.

## Root cause

In **v5.2.10**, `unmount()` saved whether the portal was mounted **before** `resetVariables()`:

```ts
const _mounted = mounted.current; // mirrored `mount` each render
resetVariables();
// ...
if (_mounted) {
  setState(INITIAL_STATE);
}
```

In **v5.2.11**, the equivalent branch checked `statusRef` **after** `resetVariables()`, which always sets `statusRef` to `INITIAL`. The guard therefore never matched and `setState(INITIAL_STATE)` was skipped.

The condition also only considered `PRESENTED` and `ANIMATING`, while a completed dismiss ends as `DISMISSED`—so it would be wrong even if evaluated before reset.

## Fix

Mirror `mount` into `mountRef` on every render (same pattern as `mounted.current = mount` in v5.2.10). In `unmount()`, read `hadReactMount = mountRef.current` **before** `resetVariables()`, then call `setState(INITIAL_STATE)` when `hadReactMount` is true.

## Testing

- `yarn lint` (biome) on `./src` passes.
- `yarn typescript` still reports existing errors in other files on this branch (unchanged by this PR).

## Checklist

- [x] Minimal, targeted change
- [ ] Maintainer may want a repro example or regression test for modal + navigation


Made with [Cursor](https://cursor.com)