### PR TITLE
fix: do not block mount animation when only keyboard is animating (#2661)

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -967,10 +967,15 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          */
         if (!didAnimateOnMount.value) {
           /**
-           * if there's a running animation (like force close), respect it and don't
-           * override with mount animation
+           * If a *close* animation is already running, do not override it with the mount
+           * animation (#2655). Keyboard-driven animations can also be RUNNING during this
+           * phase (e.g. TextInput autoFocus); those must not block mount or the sheet stays
+           * misaligned with the keyboard (#2661).
            */
-          if (animationStatus === ANIMATION_STATUS.RUNNING) {
+          if (
+            animationStatus === ANIMATION_STATUS.RUNNING &&
+            (isForcedClosing || nextIndex === -1)
+          ) {
             return;
           }
           /**


### PR DESCRIPTION
## Problem

Fixes https://github.com/gorhom/react-native-bottom-sheet/issues/2661

With **BottomSheetModal** + **BottomSheetTextInput** + **`autoFocus`**, the keyboard can open while `didAnimateOnMount` is still false. In that situation the sheet content can stay **behind** the keyboard. Focusing manually after the sheet is open (or after `onChange`) avoids the issue—a race between **mount** and **keyboard** animations.

## Root cause

PR https://github.com/gorhom/react-native-bottom-sheet/pull/2655 (`ad41447`, v5.2.10) added an early return in `evaluatePosition` for the mount phase:

```ts
if (!didAnimateOnMount.value) {
  if (animationStatus === ANIMATION_STATUS.RUNNING) {
    return;
  }
  // mount animation...
}
```

That correctly prevents the **mount** animation from overriding a **close** animation (e.g. `forceClose`), but it also treats **any** running animation the same way—including **keyboard** repositioning triggered by `autoFocus`. The mount path then never runs, and the sheet ends up misaligned with the keyboard.

## Fix

Only skip the mount animation when a **close** is in progress:

- `isForcedClosing` (force close / modal dismiss path), or
- `nextIndex === -1` (animating to the closed detent).

If the only `RUNNING` animation is keyboard-driven (`nextIndex` typically ≥ 0), the mount animation is **not** blocked.

## Testing

- `yarn biome check` on the touched file (via pre-commit / lint-staged).
- Manual: reproduce Snack from https://github.com/gorhom/react-native-bottom-sheet/issues/2661 — scenario with `autoFocus` should push content above the keyboard again.
- Regression: rapid `present` / `close` on `BottomSheetModal` (#2655) should still not freeze; close animations must still win over mount.

## Related

- Introduced by: #2655 (`ad41447`)
- Reported: #2661
