### PR TITLE
fix: replace Dimensions.get with animatedLayoutState in handleOnEnd worklet

### DIFF
--- a/src/hooks/useGestureEventsHandlersDefault.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { Dimensions, Keyboard, Platform } from 'react-native';
+import { Keyboard, Platform } from 'react-native';
 import { runOnJS, useSharedValue } from 'react-native-reanimated';
 import {
   ANIMATION_SOURCE,
@@ -345,7 +345,7 @@ export const useGestureEventsHandlersDefault: GestureEventsHandlersHookType =
            *
            * because the the keyboard dismiss is interactive in iOS.
            */
-          const WINDOW_HEIGHT = Dimensions.get('window').height;
+          const WINDOW_HEIGHT = animatedLayoutState.get().containerHeight;
           if (
             !(
               Platform.OS === 'ios' &&


### PR DESCRIPTION
## Problem

`handleOnEnd` in `useGestureEventsHandlersDefault.tsx` runs as a Reanimated worklet on the UI thread. Inside it, `Dimensions.get('window').height` is called to determine whether to dismiss the keyboard:

```ts
const WINDOW_HEIGHT = Dimensions.get('window').height;
if (!(Platform.OS === 'ios' && isScrollable && absoluteY > WINDOW_HEIGHT - animatedKeyboardState.get().heightWithinContainer)) {
  runOnJS(dismissKeyboard)();
}
```

`Dimensions` is a JS-only module — it is not available on the UI thread. This causes a crash:

```
TypeError: Dimensions.get is not a function (it is undefined)
```

The crash is reliably reproduced by:
1. Opening a bottom sheet with `keyboardBehavior="interactive"` that contains a text input
2. Focusing the input (keyboard appears)
3. Swiping down to dismiss the sheet

## Fix

`animatedLayoutState` is already in scope within the worklet and its `containerHeight` is the equivalent of `Dimensions.get('window').height` in this context — it holds the container height as a shared value accessible on the UI thread.

```ts
const WINDOW_HEIGHT = animatedLayoutState.get().containerHeight;
```

Also removed the now-unused `Dimensions` import.