### PR TITLE
fix: make dismiss() idempotent on a never-presented modal (#2669)

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -273,8 +273,9 @@ function BottomSheetModalComponent<T = never>(
       }
 
       /**
-       * if the modal position is already in a closed position,
-       * then we unmount the node and early exit.
+       * if the modal has no inner sheet to animate (never presented,
+       * already closed, or minimized), then we unmount the node and
+       * early exit.
        */
       if (
         [

--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -277,9 +277,11 @@ function BottomSheetModalComponent<T = never>(
        * then we unmount the node and early exit.
        */
       if (
-        [MODAL_STATUS.CLOSED, MODAL_STATUS.MINIMIZED].includes(
-          statusRef.current
-        ) ||
+        [
+          MODAL_STATUS.INITIAL,
+          MODAL_STATUS.CLOSED,
+          MODAL_STATUS.MINIMIZED,
+        ].includes(statusRef.current) ||
         (statusRef.current === MODAL_STATUS.DISMISSING &&
           currentIndexRef.current === -1)
       ) {


### PR DESCRIPTION
Fixes #2669.

## Summary

`BottomSheetModal.handleDismiss` treats a never-presented modal (status `INITIAL`) as if it were mid-flight: it sets `statusRef` to `DISMISSING` and calls `forceClose` on a `bottomSheetRef` that is `null` because the inner `<Portal>` hasn't mounted. The forced-close never produces an `onClose` callback, so the status remains `DISMISSING` forever and every subsequent `present()` is silently swallowed by `handlePortalRender`'s DISMISSING-status check.

## Fix

Add `MODAL_STATUS.INITIAL` to the existing early-exit list in `handleDismiss`. For a never-presented modal, `dismiss()` becomes a clean no-op (status briefly `DISMISSED`, then `unmount()` resets it to `INITIAL` via `resetVariables()`), and `present()` works again.

## Reproduction (before this PR)

https://snack.expo.dev/@ycm.jason/bottomsheetmodal-v5-2-14-dismiss-before-first-present-is-broken

Or: render a `BottomSheetModal` and call `dismiss()` in a mount-time `useEffect`. The modal never opens on subsequent `present()` calls.

This shape is common in declarative wrappers that translate a `visible: boolean` prop into imperative `present()` / `dismiss()` calls — on first mount with `visible=false`, the cleanup-style call to `dismiss()` corrupts the state machine.

## Why the fix is safe

For an `INITIAL`-status modal entering the early-exit branch:
- `statusRef` is set to `DISMISSED` momentarily, then reset to `INITIAL` by `resetVariables()` inside `unmount()`.
- `unmountSheet(key)` is a no-op because the sheet was never in the provider's queue.
- `unmountPortal(key)` is a no-op.
- `setState(INITIAL_STATE)` is a no-op because state is already `INITIAL_STATE`.
- If `onDismiss` was provided, it fires once.

The net effect is "no state change, one onDismiss callback" — the correct semantic for dismissing a never-opened modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)