### PR TITLE
fix: let user-initiated snaps interrupt a forceClose

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1176,7 +1176,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          * - already animating to next position.
          */
         const { nextPosition } = animatedAnimationState.get();
-        if (!isLayoutCalculated || targetPosition === nextPosition) {
+        if (!isLayoutCalculated.value || targetPosition === nextPosition) {
           return;
         }
 
@@ -1391,7 +1391,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          */
         const { nextPosition, nextIndex } = animatedAnimationState.get();
         if (
-          !isLayoutCalculated ||
+          !isLayoutCalculated.value ||
           nextIndex === 0 ||
           targetPosition === nextPosition
         ) {

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1126,15 +1126,12 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
        * exit method if :
        * - layout is not calculated.
        * - already animating to next position.
-       * - sheet is forced closing.
        */
-      const { nextPosition, nextIndex, isForcedClosing } =
-        animatedAnimationState.get();
+      const { nextPosition, nextIndex } = animatedAnimationState.get();
       if (
         !isLayoutCalculated.value ||
         index === nextIndex ||
-        targetPosition === nextPosition ||
-        isForcedClosing
+        targetPosition === nextPosition
       ) {
         return;
       }
@@ -1177,14 +1174,9 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          * exit method if :
          * - layout is not calculated.
          * - already animating to next position.
-         * - sheet is forced closing.
          */
-        const { nextPosition, isForcedClosing } = animatedAnimationState.get();
-        if (
-          !isLayoutCalculated ||
-          targetPosition === nextPosition ||
-          isForcedClosing
-        ) {
+        const { nextPosition } = animatedAnimationState.get();
+        if (!isLayoutCalculated || targetPosition === nextPosition) {
           return;
         }
 
@@ -1344,15 +1336,12 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          * exit method if :
          * - layout is not calculated.
          * - already animating to next position.
-         * - sheet is forced closing.
          */
-        const { nextPosition, nextIndex, isForcedClosing } =
-          animatedAnimationState.get();
+        const { nextPosition, nextIndex } = animatedAnimationState.get();
         if (
           !isLayoutCalculated.value ||
           targetIndex === nextIndex ||
-          targetPosition === nextPosition ||
-          isForcedClosing
+          targetPosition === nextPosition
         ) {
           return;
         }
@@ -1399,15 +1388,12 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          * exit method if :
          * - layout is not calculated.
          * - already animating to next position.
-         * - sheet is forced closing.
          */
-        const { nextPosition, nextIndex, isForcedClosing } =
-          animatedAnimationState.get();
+        const { nextPosition, nextIndex } = animatedAnimationState.get();
         if (
           !isLayoutCalculated ||
           nextIndex === 0 ||
-          targetPosition === nextPosition ||
-          isForcedClosing
+          targetPosition === nextPosition
         ) {
           return;
         }


### PR DESCRIPTION
## Summary

Calling `present()` on a `BottomSheetModal` while a previous `dismiss()`'s `forceClose` animation is still in flight leaves the modal unmounted under a still-`visible` consumer. This is extremely common in declarative `visible: boolean` wrappers around `BottomSheetModal` — any rapid dismiss-then-present sequence (e.g. user re-tapping the open trigger right after a commit) triggers it.

## Root cause

`BottomSheetModal.handlePresent` defends against this case by calling `bottomSheetRef.current.snapToIndex(index)` on the inner sheet. But the inner `BottomSheet.handleSnapToIndex` (and its siblings `handleSnapToPosition` / `handleExpand` / `handleCollapse`) has an early-exit guard on `isForcedClosing` that silently swallows the call. The forceClose animation runs to completion, fires `handleOnChange(-1)` → modal status becomes `MINIMIZED` → `handleBottomSheetOnClose` falls into the `enableDismissOnClose=true` else-branch → status becomes `DISMISSED` → `unmount()`. The modal is gone, but the controlling consumer still has `visible=true`, so its `useEffect` does not re-fire and the modal is stuck.

The downstream `animateToPosition` already handles cancellation correctly via `stopAnimation()` + Reanimated's `cancelAnimation()`:

- `cancelAnimation(animatedPosition)` causes the in-flight animation's `onComplete` to fire with `isFinished=false`, which `animateToPositionCompleted` early-returns on (so no stale `handleOnChange(-1)` / `handleOnClose()` is emitted).
- `animatedAnimationState.set({ status: STOPPED, source: NONE })` replaces the entire state object, which clears `isForcedClosing` as a side effect.

So the guard is unnecessarily defensive — it blocks the legitimate "user wants to interrupt the forceClose" case. The cleanup logic in `evaluatePosition` that does care about `isForcedClosing` is already gated on `source !== ANIMATION_SOURCE.USER`, i.e. it already implements the policy that user-initiated animations can interrupt a forceClose.

## Fix

Remove the `isForcedClosing` check from the early-exit guard in:

- `handleSnapToIndex`
- `handleSnapToPosition`
- `handleExpand`
- `handleCollapse`

`handleClose` and `handleForceClose` keep their guards intentionally — closing-while-force-closing is redundant (same target position), and double-forceClose is a no-op anyway.

### Drive-by

A second commit fixes a pre-existing latent bug Copilot flagged on the first commit: `handleSnapToPosition` and `handleCollapse` were checking `!isLayoutCalculated` instead of `!isLayoutCalculated.value`. Since `isLayoutCalculated` is a `SharedValue<boolean>` (a truthy object), the bare check was always `false` and the layout-readiness guard was dead code in those two methods. The other public methods already use `.value`; this commit just aligns the remaining two.

## Reproduction

**Snack:** https://snack.expo.dev/@ycm.jason/reproduction---present-during-forceclose-silently-unmounts-modal

The Snack uses a 1-second timing config so the race window is easy to hit by hand. Steps:

1. Tap **Toggle** → sheet animates in.
2. Tap **Toggle** again → sheet starts animating out (1s close).
3. **While the close animation is still running** (within that 1s window), tap **Toggle** a third time.

What's happening under the hood: tap 2 sets `visible=false`, the controlling `useEffect` calls `dismiss()` which starts a `forceClose`. Tap 3 sets `visible=true`, the `useEffect` calls `present()`, which internally calls `bottomSheetRef.current.snapToIndex(index)` on the still-mounted inner sheet.

**Before this PR:** that `snapToIndex` is swallowed by the `isForcedClosing` guard. The original forceClose runs to completion, the modal unmounts. The consumer's state is still `visible=true`, so no further `useEffect` fires and the sheet is stuck. Tapping **Toggle** again toggles `visible` back to `false` (no visible change since the modal is already gone), and the cycle has to be broken by toggling twice.

**After this PR:** the `snapToIndex` call cancels the in-flight forceClose via `stopAnimation()` and animates back to the presented index. No stale `onChange(-1)` / `onClose` fires.

The minimal repro code (also in the Snack):

```tsx
import {
  BottomSheetModal,
  BottomSheetModalProvider,
  BottomSheetView,
  useBottomSheetTimingConfigs,
} from '@gorhom/bottom-sheet';
import { useEffect, useRef, useState } from 'react';
import { Button, StyleSheet, Text } from 'react-native';
import { GestureHandlerRootView } from 'react-native-gesture-handler';
import { Easing } from 'react-native-reanimated';

const Sheet = ({ visible }: { visible: boolean }) => {
  const ref = useRef<BottomSheetModal>(null);
  const animationConfigs = useBottomSheetTimingConfigs({
    duration: 1000,
    easing: Easing.inOut(Easing.ease),
  });

  useEffect(() => {
    if (visible) ref.current?.present();
    else ref.current?.dismiss();
  }, [visible]);

  return (
    <BottomSheetModal
      ref={ref}
      snapPoints={['50%']}
      animationConfigs={animationConfigs}
    >
      <BottomSheetView style={styles.content}>
        <Text>Awesome 🎉</Text>
      </BottomSheetView>
    </BottomSheetModal>
  );
};

export default function App() {
  const [open, setOpen] = useState(false);
  return (
    <GestureHandlerRootView style={{ flex: 1, padding: 24 }}>
      <BottomSheetModalProvider>
        <Button title="Toggle" onPress={() => setOpen(p => !p)} />
        <Sheet visible={open} />
      </BottomSheetModalProvider>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  content: { alignItems: 'center', justifyContent: 'center', minHeight: 200 },
});
```

> In a real app the close animation is much shorter (~250ms), but the bug is the same — it just requires a faster tap, which users routinely hit when they re-trigger the open action right after a commit / dismiss.

## Test plan

- [ ] Run the Snack repro on the unpatched library — confirm the modal gets stuck after a fast Toggle / Toggle / Toggle.
- [ ] Run it again against this PR — confirm the in-flight close is interrupted and the sheet animates back up.
- [ ] Verify existing example apps still close/expand/collapse/snap as expected (the four affected methods are user-facing imperative APIs).
- [ ] Verify no stale `onChange(-1)` / `onClose` callbacks fire when a forceClose is interrupted by `present()`.