### PR TITLE
fix(android): declare gesture simultaneousness bidirectionally between content pan and scroll

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useState,
 } from 'react';
 import { Dimensions, Platform, StyleSheet } from 'react-native';
 import { State } from 'react-native-gesture-handler';
@@ -38,6 +39,8 @@ import {
   BottomSheetInternalProvider,
   BottomSheetProvider,
 } from '../../contexts';
+import { NativeScrollGestureContext } from '../../contexts/gesture';
+import type { Gesture as RNGHGesture } from 'react-native-gesture-handler/lib/typescript/handlers/gestures/gesture';
 import {
   useAnimatedDetents,
   useAnimatedKeyboard,
@@ -92,6 +95,41 @@ type BottomSheet = BottomSheetMethods;
 
 const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
   function BottomSheet(props, ref) {
+    /**
+     * Stores the inner scrollable's native gesture so the content pan can
+     * declare `simultaneousWithExternalGesture(nativeScroll)` bidirectionally.
+     * See `NativeScrollGestureContext` for the rationale (one-sided
+     * simultaneousness is insufficient on Android).
+     */
+    const [nativeScrollGesture, setNativeScrollGestureRaw] =
+      useState<RNGHGesture | null>(null);
+    /**
+     * Idempotent setter: once a non-null gesture is registered, subsequent
+     * non-null registrations are ignored. Without this guard the system
+     * loops infinitely — setting the gesture re-renders the pan with new
+     * simultaneousHandlers, which feeds a new `draggableGesture` into the
+     * scrollable via context, which causes the scrollable's `useMemo` to
+     * rebuild `scrollableGesture`, whose new identity re-fires the
+     * registration effect, and so on. The bidirectional relation only needs
+     * to be established once; further updates would only churn the gesture
+     * tree without changing semantics.
+     */
+    const setNativeScrollGesture = useCallback(
+      (gesture: RNGHGesture | null) => {
+        setNativeScrollGestureRaw((prev) => {
+          if (prev !== null && gesture !== null) {
+            return prev;
+          }
+          return gesture;
+        });
+      },
+      []
+    );
+    const nativeScrollGestureContextValue = useMemo(
+      () => ({ nativeScrollGesture, setNativeScrollGesture }),
+      [nativeScrollGesture, setNativeScrollGesture]
+    );
+
     //#region extract props
     const {
       // animations configurations
@@ -1794,6 +1832,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     return (
       <BottomSheetProvider value={externalContextVariables}>
         <BottomSheetInternalProvider value={internalContextVariables}>
+          <NativeScrollGestureContext.Provider value={nativeScrollGestureContextValue}>
           <BottomSheetGestureHandlersProvider
             gestureEventsHandlersHook={gestureEventsHandlersHook}
           >
@@ -1869,6 +1908,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
               /> */}
             </BottomSheetHostingContainer>
           </BottomSheetGestureHandlersProvider>
+          </NativeScrollGestureContext.Provider>
         </BottomSheetInternalProvider>
       </BottomSheetProvider>
     );

--- a/src/components/bottomSheetDraggableView/BottomSheetDraggableView.tsx
+++ b/src/components/bottomSheetDraggableView/BottomSheetDraggableView.tsx
@@ -1,7 +1,10 @@
-import React, { memo, useMemo } from 'react';
+import React, { memo, useContext, useMemo } from 'react';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated from 'react-native-reanimated';
-import { BottomSheetDraggableContext } from '../../contexts/gesture';
+import {
+  BottomSheetDraggableContext,
+  NativeScrollGestureContext,
+} from '../../contexts/gesture';
 import {
   useBottomSheetGestureHandlers,
   useBottomSheetInternal,
@@ -26,6 +29,16 @@ const BottomSheetDraggableViewComponent = ({
     failOffsetY,
   } = useBottomSheetInternal();
   const { contentPanGestureHandler } = useBottomSheetGestureHandlers();
+  /**
+   * The inner scrollable component registers its native scroll gesture here so
+   * we can declare `simultaneousWithExternalGesture(nativeScroll)` on the pan,
+   * matching the scrollable side's own `simultaneousWithExternalGesture(pan)`
+   * declaration. Without this bidirectional declaration, the parent pan
+   * cancels the child native scroll on every drag on Android (one-sided
+   * simultaneousness is insufficient there).
+   */
+  const nativeScrollGestureCtx = useContext(NativeScrollGestureContext);
+  const nativeScrollGesture = nativeScrollGestureCtx?.nativeScrollGesture;
   //#endregion
 
   //#region variables
@@ -38,6 +51,10 @@ const BottomSheetDraggableViewComponent = ({
 
     if (refreshControlGestureRef) {
       refs.push(refreshControlGestureRef);
+    }
+
+    if (nativeScrollGesture) {
+      refs.push(nativeScrollGesture);
     }
 
     if (_providedSimultaneousHandlers) {
@@ -53,6 +70,7 @@ const BottomSheetDraggableViewComponent = ({
     _providedSimultaneousHandlers,
     nativeGestureRef,
     refreshControlGestureRef,
+    nativeScrollGesture,
   ]);
   const draggableGesture = useMemo(() => {
     let gesture = Gesture.Pan()

--- a/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
+++ b/src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx
@@ -1,8 +1,10 @@
 import React, {
   forwardRef,
   useContext,
+  useEffect,
   useImperativeHandle,
   useMemo,
+  useRef,
 } from 'react';
 import { Gesture } from 'react-native-gesture-handler';
 import { useAnimatedProps } from 'react-native-reanimated';
@@ -11,7 +13,10 @@ import {
   SCROLLABLE_STATUS,
   type SCROLLABLE_TYPE,
 } from '../../constants';
-import { BottomSheetDraggableContext } from '../../contexts/gesture';
+import {
+  BottomSheetDraggableContext,
+  NativeScrollGestureContext,
+} from '../../contexts/gesture';
 import {
   useBottomSheetContentContainerStyle,
   useBottomSheetInternal,
@@ -55,6 +60,14 @@ export function createBottomSheetScrollableComponent<T, P>(
 
     //#region hooks
     const draggableGesture = useContext(BottomSheetDraggableContext);
+    /**
+     * Registers our native scroll gesture with the outer `BottomSheetDraggableView`,
+     * which adds it to its `simultaneousWithExternalGesture` array on the pan.
+     * This makes the simultaneousness bidirectional — required for RNGH on
+     * Android to coordinate the pan and the native scroll without one
+     * canceling the other.
+     */
+    const nativeScrollGestureCtx = useContext(NativeScrollGestureContext);
     const { scrollableRef, scrollableContentOffsetY, scrollHandler } =
       useScrollHandler(
         scrollEventsHandlersHook,
@@ -95,6 +108,45 @@ export function createBottomSheetScrollableComponent<T, P>(
           : undefined,
       [draggableGesture]
     );
+
+    /**
+     * Register this scrollable's native gesture with the outer
+     * `BottomSheetDraggableView` so it can add the gesture to its pan's
+     * `simultaneousWithExternalGesture` array, completing the bidirectional
+     * simultaneousness declaration. This triggers a re-render of the parent
+     * `BottomSheet` (state update), which recomputes the pan's `useMemo` and
+     * re-attaches its `GestureDetector` with the relation now in place. A
+     * ref-based approach would not work here because RNGH resolves the
+     * gesture object eagerly and would see `null` at registration time;
+     * subsequent ref mutations are not picked up.
+     *
+     * No cleanup on deps change: nulling the registration would re-render
+     * the pan without the scroll in `simultaneousHandlers`, which feeds a
+     * different `draggableGesture` back through context and rebuilds
+     * `scrollableGesture`, which re-fires this effect — an infinite loop.
+     * The parent setter is idempotent (first non-null registration wins),
+     * so subsequent calls during the same component lifetime are no-ops.
+     * Unmount cleanup is handled separately below.
+     */
+    useEffect(() => {
+      if (!nativeScrollGestureCtx || !scrollableGesture) {
+        return;
+      }
+      nativeScrollGestureCtx.setNativeScrollGesture(scrollableGesture);
+    }, [scrollableGesture, nativeScrollGestureCtx]);
+
+    /**
+     * Unmount-only cleanup. Captures the latest context in a ref so the
+     * cleanup callback always nulls the current registration when the
+     * scrollable fully unmounts (e.g. when the bottom sheet closes).
+     */
+    const nativeScrollGestureCtxRef = useRef(nativeScrollGestureCtx);
+    nativeScrollGestureCtxRef.current = nativeScrollGestureCtx;
+    useEffect(() => {
+      return () => {
+        nativeScrollGestureCtxRef.current?.setNativeScrollGesture(null);
+      };
+    }, []);
     //#endregion
 
     //#region callbacks

--- a/src/contexts/gesture.ts
+++ b/src/contexts/gesture.ts
@@ -11,3 +11,31 @@ export const BottomSheetGestureHandlersContext =
   createContext<BottomSheetGestureHandlersContextType | null>(null);
 
 export const BottomSheetDraggableContext = createContext<Gesture | null>(null);
+
+/**
+ * Allows the inner scrollable component (`createBottomSheetScrollableComponent`)
+ * to register its native scroll gesture with the outer `BottomSheetDraggableView`,
+ * so the content pan gesture can declare `simultaneousWithExternalGesture(nativeScroll)`
+ * — making the simultaneousness bidirectional.
+ *
+ * Without this, only the scroll side declares simultaneousness with the pan
+ * (`Gesture.Native().simultaneousWithExternalGesture(panGesture)`). On Android
+ * one-sided declaration is insufficient: the parent pan cancels the child native
+ * scroll on every drag (visible symptom: `onBeginDrag` fires multiple times in
+ * succession with zero `onScroll` events). Declaring on both sides resolves the
+ * conflict and lets RNGH coordinate them correctly.
+ *
+ * State (not ref) is required because `simultaneousWithExternalGesture` resolves
+ * at gesture-handler registration time. A ref whose `.current` is null at that
+ * moment results in no relation being established; subsequent ref mutations
+ * aren't picked up. Using state forces a re-render when the native gesture
+ * mounts, recomputing the pan's `simultaneousHandlers` array and re-attaching
+ * the GestureDetector with the relation now in place.
+ */
+export interface NativeScrollGestureContextType {
+  nativeScrollGesture: Gesture | null;
+  setNativeScrollGesture: (gesture: Gesture | null) => void;
+}
+
+export const NativeScrollGestureContext =
+  createContext<NativeScrollGestureContextType | null>(null);


### PR DESCRIPTION
## Motivation

On Android, the inner scrollable inside a `BottomSheet` cannot be scrolled when the sheet is first opened. Dragging vertically inside the scrollable does nothing — the content pan gesture cancels the native scroll on every touch. Curiously, focusing then blurring a `TextInput` inside the sheet "fixes" the problem for the remainder of that session, after which the scroll works normally.

Diagnostic instrumentation showed the symptom precisely: `onScrollBeginDrag` fires **4×** in succession with **zero** `onScroll` events between them — i.e. RNGH keeps starting the scroll and immediately canceling it in favor of the pan.

### Root cause

`BottomSheetDraggableView` creates the content pan gesture with:

```ts
gesture = gesture.simultaneousWithExternalGesture(simultaneousHandlers as never);
```

…where `simultaneousHandlers` is built from `nativeGestureRef`, `refreshControlGestureRef`, and any user-provided handlers. It **does not** include the inner scrollable's `Gesture.Native()`.

Meanwhile, `createBottomSheetScrollableComponent` does declare the relation on the scroll side:

```ts
Gesture.Native()
  .simultaneousWithExternalGesture(draggableGesture)   // declares pan as simultaneous
  .shouldCancelWhenOutside(false)
```

So the simultaneousness is only declared on one side. RNGH on Android requires the declaration on **both** sides — on iOS the one-sided declaration appears to be enough, which is why this bug only manifests on Android.

The "focus then blur an input" workaround presumably forces RNGH to re-resolve its internal gesture tree, at which point the declarations end up coordinated.

## What this PR does

Introduces a `NativeScrollGestureContext` that lets the inner scrollable register its `Gesture.Native()` back up to the outer `BottomSheetDraggableView`. The pan then includes that gesture in its `simultaneousWithExternalGesture(...)` array, completing the bidirectional declaration.

Three notable implementation choices, each captured in inline JSDoc on the changed files:

### 1. State, not ref

`simultaneousWithExternalGesture` resolves its argument at gesture-handler registration time. A ref whose `.current` is `null` at that moment results in no relation being established, and subsequent ref mutations are not picked up — RNGH does not lazily re-resolve.

A `useState` is therefore required: when the inner scrollable mounts and registers its gesture, the resulting state update re-renders the `BottomSheet`, recomputes the pan's `useMemo`, and re-attaches its `GestureDetector` with the relation now in place.

### 2. Setter is idempotent (first non-null wins)

Without a guard, the setter would loop:

> set scroll → state update → pan re-creates → new pan flows into the scrollable via `BottomSheetDraggableContext` → scrollable's `useMemo` rebuilds `scrollableGesture` → effect re-fires with the new identity → set scroll → …

(Reproducible: yields a hard `Maximum update depth exceeded` after ~50 iterations.)

Once a non-null gesture is registered, subsequent non-null registrations are no-ops. The bidirectional relation only needs to be established once; further updates would only churn the gesture tree without changing semantics.

### 3. Registration effect has no deps-change cleanup; unmount cleanup lives in its own effect

For the same loop-avoidance reason: nulling the registration on every deps change would re-render the pan **without** the scroll, then re-register, then re-render the pan **with** the scroll, ad infinitum. The deps-change branch of the cleanup is dropped; a separate unmount-only effect (using a ref to capture the latest context) still clears the registration when the scrollable fully unmounts (e.g. when the sheet closes).

## Files changed

| File | Change |
|---|---|
| `src/contexts/gesture.ts` | Adds `NativeScrollGestureContext` with `{nativeScrollGesture, setNativeScrollGesture}`. JSDoc explains the why. |
| `src/components/bottomSheet/BottomSheet.tsx` | Provides the context with a `useState`-backed value and an idempotent setter. |
| `src/components/bottomSheetDraggableView/BottomSheetDraggableView.tsx` | Consumes the context and adds `nativeScrollGesture` to the pan's `simultaneousHandlers`. |
| `src/components/bottomSheetScrollable/createBottomSheetScrollableComponent.tsx` | Registers its `scrollableGesture` via the context on mount; clears on unmount. |

No public API changes. No type changes. No behavior change for any platform/scenario where the scroll already worked.

## Verification

- `yarn typescript` — clean
- `yarn lint --error-on-warnings` — clean on the four modified files (the pre-existing warning in `src/hooks/useBoundingClientRect.ts` is on `master` and untouched here)
- Manual test on a physical Android device with the example app and with my own production app: scroll inside the sheet now works on first open, no need for the focus/blur reset. iOS behavior unchanged.

## Related

This bug is the underlying cause for several long-standing reports about scroll/pan conflicts in `BottomSheet` content on Android (notably the "scroll only works after focusing an input" pattern).

Happy to break this into smaller commits, adjust the comments, or rework the context shape if you'd prefer a different approach.