### PR TITLE
fix(scrollable): preserve scroll position when keyboard dismisses

### DIFF
--- a/src/hooks/useScrollable.ts
+++ b/src/hooks/useScrollable.ts
@@ -6,6 +6,7 @@ import {
   useSharedValue,
 } from 'react-native-reanimated';
 import {
+  ANIMATION_SOURCE,
   ANIMATION_STATUS,
   KEYBOARD_STATUS,
   SCROLLABLE_STATUS,
@@ -62,13 +63,24 @@ export const useScrollable = (
     }
 
     /**
-     * if keyboard is shown and sheet is animating
-     * then we do not lock the scrolling to not lose
-     * current scrollable scroll position.
+     * If the sheet is animating because of the keyboard (in either
+     * direction — show or hide), keep the scrollable UNLOCKED so the
+     * scroll position is preserved across the transition. The previous
+     * check only covered keyboard show (`KEYBOARD_STATUS.SHOWN`); during
+     * keyboard dismiss the keyboard status reports `HIDDEN` while the
+     * sheet is still animating back from its keyboard-offset position to
+     * its rest position, and during that window `animatedSheetState`
+     * falls through to `OPENED` (since the position no longer exactly
+     * equals either the extended or the extended-with-keyboard position).
+     * Without this branch, `LOCKED` kicks in mid-animation and
+     * `handleOnScroll` forces `scrollTo(0, 0)` — jumping the user back
+     * to the top.
      */
+    const animationState = animatedAnimationState.get();
     if (
-      animatedKeyboardState.get().status === KEYBOARD_STATUS.SHOWN &&
-      animatedAnimationState.get().status === ANIMATION_STATUS.RUNNING
+      animationState.status === ANIMATION_STATUS.RUNNING &&
+      (animatedKeyboardState.get().status === KEYBOARD_STATUS.SHOWN ||
+        animationState.source === ANIMATION_SOURCE.KEYBOARD)
     ) {
       return SCROLLABLE_STATUS.UNLOCKED;
     }


### PR DESCRIPTION
## Motivation

When a `BottomSheet` contains a scrollable and a `TextInput`, the following sequence fails:

1. User scrolls down inside the sheet content.
2. User taps a `TextInput` further down — keyboard appears, sheet animates up (interactive keyboard behavior).
3. User dismisses the keyboard.
4. **The inner scroll jumps back to the top instead of staying where it was.**

The user's scroll position is lost on every keyboard dismiss, which makes long forms inside a sheet effectively unusable.

## Root cause

The relevant code in `useScrollable.ts`:

```ts
if (
  animatedKeyboardState.get().status === KEYBOARD_STATUS.SHOWN &&
  animatedAnimationState.get().status === ANIMATION_STATUS.RUNNING
) {
  return SCROLLABLE_STATUS.UNLOCKED;
}
```

This unlocks the scrollable during keyboard-show animations so the scroll position is preserved while the sheet translates. But it only matches `KEYBOARD_STATUS.SHOWN`. During the **dismiss** animation, the keyboard status has already flipped to `HIDDEN`, while the sheet is still animating back from `extendedPositionWithKeyboard` to `extendedPosition`. So this branch doesn't apply on the way down.

During that dismiss window:

- `animatedPosition` is **between** `extendedPositionWithKeyboard` and `extendedPosition`.
- `animatedSheetState` (in `BottomSheet.tsx`) checks for `animatedPosition.value === extendedPosition` (exact equality) — false during animation.
- The special "keyboard interactive + isInTemporaryPosition" branch is also bypassed because `isInTemporaryPosition` was just flipped to `false` in `getEvaluatedPosition`.
- It falls through to `SHEET_STATE.OPENED`.

With sheet state `OPENED` and the keyboard branch not matching, `useScrollable` returns `LOCKED`. `handleOnScroll` (in `useScrollEventsHandlersDefault.ts`) then fires `scrollTo(scrollableRef, 0, lockPosition, false)`. Because the user started dragging while the sheet was `EXTENDED`, `shouldLockInitialPosition` is `false`, so `lockPosition = 0` — instant jump to top.

The bug only manifests because `OPENED` is reached **mid-animation**. Once the animation completes and `position === extendedPosition` again, `animatedSheetState` flips back to `EXTENDED` and unlocks the scroll — too late, the `scrollTo(0)` has already fired.

## What this PR does

Extends the unlock condition to also cover keyboard-dismiss animations by checking the animation's `source`:

```ts
const animationState = animatedAnimationState.get();
if (
  animationState.status === ANIMATION_STATUS.RUNNING &&
  (animatedKeyboardState.get().status === KEYBOARD_STATUS.SHOWN ||
    animationState.source === ANIMATION_SOURCE.KEYBOARD)
) {
  return SCROLLABLE_STATUS.UNLOCKED;
}
```

`animationState.source === ANIMATION_SOURCE.KEYBOARD` is true for both the show and dismiss animations triggered by the keyboard state machine, so it cleanly covers the missing case without weakening the existing one.

## Files changed

- `src/hooks/useScrollable.ts` — extended unlock condition; added an `ANIMATION_SOURCE` import.

No API changes, no type changes.

## Verification

- `yarn typescript` — clean
- `yarn lint --error-on-warnings src/hooks/useScrollable.ts` — clean
- Manual test on Android with a `BottomSheetScrollView` containing several inputs: scroll position is now preserved across keyboard show and dismiss. Behavior unchanged for non-keyboard animations and for sheets without keyboard interactions.

## Notes

This is a **pure scroll-preservation fix** and is independent of #2675 (which fixes a separate Android-only scroll-cancellation bug on first sheet open). Either can land independently.