### PR TITLE
fix: rename window variable to avoid Hermes global collision and add listener cleanup

### DIFF
--- a/src/hooks/useAnimatedLayout.ts
+++ b/src/hooks/useAnimatedLayout.ts
@@ -106,13 +106,14 @@ export function useAnimatedLayout(
     [state, verticalInset, modal]
   );
   useEffect(() => {
-    Dimensions.addEventListener('change', ({ window }) => {
+    const subscription = Dimensions.addEventListener('change', ({ window: windowDimensions }) => {
       state.modify(_state => {
         'worklet';
-        _state.window = window;
+        _state.window = windowDimensions;
         return _state;
       });
     });
+    return () => subscription.remove();
   }, [state]);
   //#endregion
 


### PR DESCRIPTION
Fixes https://github.com/gorhom/react-native-bottom-sheet/issues/2678

## Problem

In `useAnimatedLayout.ts`, the `Dimensions.addEventListener` callback destructures the event as `{ window }`. On the Hermes JS engine, worklets run in a UI runtime that exposes a global `window` object. When a `Dimensions` change fires (app switching, entering Maps/Camera, device rotation) while a bottom sheet is mounted, Hermes resolves the captured `window` variable through its global lookup instead of the local destructured value — causing a crash.

Additionally, the listener was never cleaned up: the `useEffect` returned nothing, so the subscription leaked on every unmount.

## Fix

- Renames the destructured parameter from `window` to `windowDimensions` to avoid the collision with the Hermes global.
- Stores the subscription returned by `addEventListener` and calls `subscription.remove()` in the effect cleanup.
