### PR TITLE
fix(layout): seed containerHeight on mount when raw->container reaction is missed (Reanimated 4)

### DIFF
--- a/src/components/bottomSheetHostingContainer/BottomSheetHostingContainer.tsx
+++ b/src/components/bottomSheetHostingContainer/BottomSheetHostingContainer.tsx
@@ -8,6 +8,7 @@ import {
   View,
   type ViewStyle,
 } from 'react-native';
+import { INITIAL_LAYOUT_VALUE } from '../../constants';
 import { print } from '../../utilities';
 import { styles } from './styles';
 import type { BottomSheetHostingContainerProps } from './types';
@@ -61,6 +62,16 @@ function BottomSheetHostingContainerComponent({
         layoutState.modify(state => {
           'worklet';
           state.rawContainerHeight = height;
+          // `useAnimatedLayout` mirrors `rawContainerHeight` into `containerHeight`
+          // through a `useAnimatedReaction`. On Reanimated 4 that reaction can miss
+          // the initial `INITIAL_LAYOUT_VALUE` -> height transition (the handler does
+          // not fire for the first `modify`), leaving `containerHeight` at the
+          // sentinel so snap points never normalize and the sheet stays off screen.
+          // Seed a non-sentinel value here so layout can complete; the reaction still
+          // refines it (e.g. modal vertical inset) whenever it runs.
+          if (state.containerHeight === INITIAL_LAYOUT_VALUE) {
+            state.containerHeight = height;
+          }
           return state;
         });
       }


### PR DESCRIPTION
## Summary

Fixes #2688.

On Android, a non-modal `BottomSheet` with an initial `index >= 0` can mount **invisible** — it renders into the tree but stays positioned off screen and never animates in. It's intermittent in general and reproduces reliably when the screen mounts under JS-thread contention (so the container `onLayout` lands a beat after mount).

### Root cause

`useAnimatedLayout` derives the effective `containerHeight` from `rawContainerHeight` via a `useAnimatedReaction`. On **Reanimated 4** that reaction can miss the initial `INITIAL_LAYOUT_VALUE` → measured-height transition (the handler doesn't run for the first `layoutState.modify`), so `containerHeight` is stuck at the sentinel even though `rawContainerHeight` is correct. From there `useAnimatedDetents` early-exits, `isLayoutCalculated` never turns `true`, and the mount positioning reaction never runs `animateToPosition`/`setToPosition` — the sheet is left at its initial `window.height` (off-screen) position.

`useDerivedValue` consumers of the same state recompute fine on the `modify`; only the `useAnimatedReaction` handler is skipped, which points at a Reanimated-4 reaction/`modify` timing issue.

Captured on a failing Android cold start:

```
[BottomSheetHostingContainer::handleLayoutEvent] height:832
isLayoutCalc containerH=-999 rawContainerH=832 handleH=0 detents=none -> false
```

### Change

Seed a non-sentinel `containerHeight` in `BottomSheetHostingContainer`'s layout handler, in the same `modify` that writes `rawContainerHeight`, **only while it is still the sentinel**. The existing reaction keeps refining the value (e.g. modal vertical inset) whenever it does run, so normal behavior is unchanged when the reaction fires — this only unblocks the case where it doesn't.

```ts
state.rawContainerHeight = height;
if (state.containerHeight === INITIAL_LAYOUT_VALUE) {
  state.containerHeight = height;
}
```

## Test plan

- Verified in a real RN 0.81 app (Reanimated 4.4.0, GH 2.31.1) on Android (Samsung A54): before the change the dashboard sheet was invisible on every cold launch; after, it positions to `index 0` on every launch (`animateToPositionCompleted … nextIndex:0`) and renders correctly.
- Behavior unchanged when the raw→container reaction fires normally (the seed is sentinel-guarded; the reaction still owns the final value, including the modal inset path).

## Notes

`animateOnMount={false}` is not a workaround for this — it independently prevents positioning (it sets `didAnimateOnMount = true`, and the layout-ready branch that calls `setToPosition` is gated on `!didAnimateOnMount`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
