### PR TITLE
fix: preserve list callback types for bottom sheet scrollables

### DIFF
--- a/src/components/bottomSheetScrollable/types.d.ts
+++ b/src/components/bottomSheetScrollable/types.d.ts
@@ -204,8 +204,17 @@ export interface BottomSheetScrollViewMethods {
 //#region SectionList
 export type BottomSheetSectionListProps<ItemT, SectionT> = Omit<
   AnimatedProps<SectionListProps<ItemT, SectionT>>,
-  'decelerationRate' | 'scrollEventThrottle'
-> &
+  | 'decelerationRate'
+  | 'scrollEventThrottle'
+  | 'keyExtractor'
+  | 'renderItem'
+  | 'renderSectionHeader'
+  | 'renderSectionFooter'
+ > &
+  Pick<
+    SectionListProps<ItemT, SectionT>,
+    'keyExtractor' | 'renderItem' | 'renderSectionHeader' | 'renderSectionFooter'
+  > &
   BottomSheetScrollableProps & {
     ref?: Ref<BottomSheetSectionListMethods>;
   };

--- a/src/components/bottomSheetScrollable/types.d.ts
+++ b/src/components/bottomSheetScrollable/types.d.ts
@@ -57,8 +57,9 @@ export type ScrollableProps<T> =
 //#region FlatList
 export type BottomSheetFlatListProps<T> = Omit<
   AnimatedProps<FlatListProps<T>>,
-  'decelerationRate' | 'onScroll' | 'scrollEventThrottle'
+  'decelerationRate' | 'onScroll' | 'scrollEventThrottle' | 'keyExtractor' | 'renderItem'
 > &
+  Pick<FlatListProps<T>, 'keyExtractor' | 'renderItem'> &
   BottomSheetScrollableProps & {
     ref?: Ref<BottomSheetFlatListMethods>;
   };


### PR DESCRIPTION

## Motivation

`BottomSheetFlatList<T>` and `BottomSheetSectionList<ItemT, SectionT>` currently wrap React Native list props with `AnimatedProps`, which can lose contextual typing for generic callback props.

As a result, even when users provide explicit list generics, TypeScript may treat callback parameters like `item` or `section` as implicitly `any` under `noImplicitAny`.

This change preserves the original React Native callback prop typings for both list components:

- `BottomSheetFlatList`: `keyExtractor`, `renderItem`
- `BottomSheetSectionList`: `keyExtractor`, `renderItem`, `renderSectionHeader`, `renderSectionFooter`

The rest of the props still use `AnimatedProps`, so existing animated prop support is preserved while list callback inference works as expected.