### PR TITLE
fix: use screen height as initial position on native platforms

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -215,7 +215,12 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     const animatedCurrentIndex = useReactiveSharedValue(
       animateOnMount ? -1 : _providedIndex
     );
-    const animatedPosition = useSharedValue(Dimensions.get('window').height);
+    const animatedPosition = useSharedValue(
+      Platform.select({
+        web: Dimensions.get('window').height,
+        default: Dimensions.get('screen').height,
+      })
+    );
 
     // conditional
     const didAnimateOnMount = useSharedValue(


### PR DESCRIPTION
## Motivation

On Android devices with a virtual navigation bar (common on Android 14 and older), `Dimensions.get('window').height` excludes the navigation bar height, making it shorter than the physical screen.

Using it as the initial off-screen position causes the sheet to appear partially visible on mount before any animation runs, with its backdrop blocking all interaction. `screen.height` is the safe upper bound on native; `window.height` is preserved on web where the distinction does not apply.

This issue was introduced in [v5.2.11](https://github.com/gorhom/react-native-bottom-sheet/releases/tag/v5.2.11) by the fix for #2639 ([17ee221](https://github.com/gorhom/react-native-bottom-sheet/commit/17ee22176123f94a17f2041a60ada3017f581463)).

**Note:** this issue is difficult to replicate on Android emulators, as newer Android versions no longer use a docked virtual navigation bar by default.