### PR TITLE
fix(modal): keep minimize/dismiss status when sheet settles at closed position

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -432,8 +432,15 @@ function BottomSheetModalComponent<T = never>(
       currentIndexRef.current = _index;
       nextIndexRef.current = null;
 
-      statusRef.current =
-        _index === -1 ? MODAL_STATUS.MINIMIZED : MODAL_STATUS.PRESENTED;
+      const currentStatusIsDismissingOrMinimizing = [
+        MODAL_STATUS.DISMISSING,
+        MODAL_STATUS.MINIMIZING,
+      ].includes(statusRef.current);
+
+      if (!(currentStatusIsDismissingOrMinimizing && _index === -1)) {
+        statusRef.current =
+          _index === -1 ? MODAL_STATUS.MINIMIZED : MODAL_STATUS.PRESENTED;
+      }
 
       if (_providedOnChange) {
         _providedOnChange(_index, _position, _type);


### PR DESCRIPTION
## Motivation

This PR fixes #2685

When you use `stackBehavior="switch"` and present a child modal that's rendered inside the parent's tree, the parent gets dismissed and unmounted instead of just minimized. Since the child lives inside the parent's subtree, it gets torn down along with it and closes right away.

The cause is a small ordering issue. When `switch` minimizes the active sheet, it sets the status to `MINIMIZING` and calls `close()`. Once the sheet lands at `-1`, the core fires `onChange` and then `onClose` back to back. 
The problem is that `onChange` was overwriting the status to `MINIMIZED`, so by the time `onClose` ran it no longer saw the `MINIMIZING` intent. It fell through to the `enableDismissOnClose` branch, which defaults to `true`, treated the whole thing as a dismiss, and unmounted the sheet.

The same overwrite also broke `dismiss()` when `enableDismissOnClose` was `false`. 
The `DISMISSING` status got replaced with `MINIMIZED`, so `onClose` resolved it as `CLOSED` and the sheet never unmounted.

The fix keeps the pending `MINIMIZING` or `DISMISSING` status when the sheet settles at `-1`, and lets `onClose` resolve the final state on its own. It mirrors the guard that already exists in `handleBottomSheetOnAnimate`, so it stays consistent with how the rest of the handler works. The user-facing `onChange(-1)` callback still fires as before.