### PR TITLE
fix(BottomSheetModal): don't fire onDismiss when sheet was never presented

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -125,8 +125,10 @@ function BottomSheetModalComponent<T = never>(
         setState(INITIAL_STATE);
       }
 
-      // fire `onDismiss` callback
-      if (_providedOnDismiss) {
+      // fire `onDismiss` callback only if the sheet was actually presented.
+      // `dismiss()` on a never-presented modal would otherwise fire a phantom
+      // `onDismiss`, mirroring the `hadReactMount` guard used for the unmount above.
+      if (hadReactMount && _providedOnDismiss) {
         _providedOnDismiss();
       }
     },


### PR DESCRIPTION
## Motivation

`BottomSheetModal`'s `unmount()` fires the user-provided `onDismiss` callback **unconditionally**, even when the modal was never presented. Calling `ref.current?.dismiss()` on a modal that was never `present()`-ed therefore triggers a phantom `onDismiss`.

The function already computes `hadReactMount` and uses it to gate the React unmount (`setState`), but `onDismiss` is fired without the same guard — which is inconsistent, since `onDismiss` means "a presented sheet was dismissed".

This breaks consumers that run side effects in `onDismiss` (e.g. `navigation.goBack()`): a phantom dismiss on a permanently-mounted, never-presented modal navigates the user away. Reproducible on `react-native@0.85` / the new architecture.

Fixes #2703.

## Change

Gate the callback on the already-computed `hadReactMount`, mirroring the `setState` guard:

```ts
if (hadReactMount && _providedOnDismiss) {
  _providedOnDismiss();
}
```

One-line behavioral change; `onDismiss` now only fires for a sheet that was actually presented.

## Verification

In an app that permanently mounts a `BottomSheetModal` and calls `dismiss()` from an effect when it should be hidden, `onDismiss` no longer fires unless the sheet was presented first. Normal present → dismiss flows are unaffected (`hadReactMount` is true once presented).