### PR TITLE
Fixes an Android bug where a closed BottomSheet with a backdrop can block all touch events on the underlying screen after a cold start.

### DIFF
--- a/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
+++ b/src/components/bottomSheetBackdrop/BottomSheetBackdrop.tsx
@@ -30,6 +30,13 @@ import {
 import { styles } from './styles';
 import type { BottomSheetDefaultBackdropProps } from './types';
 
+const BACKDROP_INDEX_EPSILON = 0.01;
+
+const shouldDisableBackdropTouchability = (
+  index: number,
+  disappearsOnIndex: number
+) => index <= disappearsOnIndex + BACKDROP_INDEX_EPSILON;
+
 const BottomSheetBackdropComponent = ({
   animatedIndex,
   opacity: _providedOpacity,
@@ -62,7 +69,18 @@ const BottomSheetBackdropComponent = ({
   //#region variables
   const [pointerEvents, setPointerEvents] = useState<
     ViewProps['pointerEvents']
-  >(enableTouchThrough ? 'none' : 'auto');
+  >(() => {
+    if (enableTouchThrough) {
+      return 'none';
+    }
+
+    return shouldDisableBackdropTouchability(
+      animatedIndex.value,
+      disappearsOnIndex
+    )
+      ? 'none'
+      : 'auto';
+  });
   //#endregion
 
   //#region callbacks
@@ -120,7 +138,8 @@ const BottomSheetBackdropComponent = ({
 
   //#region effects
   useAnimatedReaction(
-    () => animatedIndex.value <= disappearsOnIndex,
+    () =>
+      shouldDisableBackdropTouchability(animatedIndex.value, disappearsOnIndex),
     (shouldDisableTouchability, previous) => {
       if (shouldDisableTouchability === previous) {
         return;
@@ -134,10 +153,20 @@ const BottomSheetBackdropComponent = ({
   // [link](https://github.com/gorhom/react-native-bottom-sheet/issues/1376)
   useEffect(() => {
     isMounted.current = true;
+
+    // Sync pointer events on mount in case the animated reaction fired before
+    // the component was mounted (https://github.com/gorhom/react-native-bottom-sheet/issues/2680)
+    const shouldDisableTouchability = shouldDisableBackdropTouchability(
+      animatedIndex.value,
+      disappearsOnIndex
+    );
+
+    setPointerEvents(shouldDisableTouchability ? 'none' : 'auto');
+
     return () => {
       isMounted.current = false;
     };
-  }, []);
+  }, [animatedIndex, disappearsOnIndex]);
   //#endregion
 
   const AnimatedView = (


### PR DESCRIPTION
Fixes an Android bug where a closed BottomSheet with a backdrop can block all touch events on the underlying screen after a cold start.

Closes #2680

Problem
When a screen mounts a closed bottom sheet (index={-1}) with a BottomSheetBackdrop, some Android devices stop receiving scroll and button presses on the content behind the sheet. The UI renders correctly, but touches appear to be swallowed. Backgrounding the app and returning restores interaction without navigating away.

Reported on devices including Samsung (Android 14) and Xiaomi (Android 11).

Root cause
Two independent issues in BottomSheetBackdrop:

1. Mount race condition
pointerEvents was always initialized to 'auto' when enableTouchThrough is false. useAnimatedReaction can fire before the mount useEffect sets isMounted.current = true. Because handleContainerTouchability only updates state when mounted, that first update is silently skipped and the invisible backdrop keeps intercepting touches.

2. Floating-point animatedIndex
On some devices, animatedIndex settles at -0.999… instead of exactly -1. With disappearsOnIndex={-1}, the check animatedIndex.value <= disappearsOnIndex evaluates to false, so pointerEvents never switches to 'none'.

Solution
Derive the initial pointerEvents value from the current animatedIndex instead of defaulting to 'auto'
Sync pointerEvents on mount to recover from the race where the animated reaction fires before the component is mounted
Use an epsilon-based closed-state check (index <= disappearsOnIndex + 0.01) so near-closed values like -0.9999 are treated as closed without affecting partially open positions during animations
How to reproduce (before fix)
Use @gorhom/bottom-sheet@5.2.14
Render a screen with scrollable content and a closed bottom sheet (index={-1})
Add a backdrop with appearsOnIndex={0} and disappearsOnIndex={-1}
Cold start on an affected Android device
Try scrolling or pressing buttons behind the sheet
Observe that touches are blocked until the app is backgrounded and resumed
<BottomSheet
  ref={sheetRef}
  index={-1}
  enableDynamicSizing
  enablePanDownToClose
  backdropComponent={renderBackdrop}
>
  ...
</BottomSheet>
Test plan

yarn typescript
passes

biome check
passes on the changed file
Cold-start repro on physical Android device (Samsung / Xiaomi class devices)
Verify backdrop still captures presses when the sheet is open
Verify
enableTouchThrough
behavior is unchanged
Verify opening/closing the sheet still works as expected
Risks / notes
The epsilon value (0.01) is intentionally small so mid-animation indices (e.g. -0.3) are not incorrectly treated as closed
This is a targeted change to BottomSheetBackdrop.tsx only; no API changes
Related community workaround was setting disappearsOnIndex={-0.5} — this fix addresses the underlying comparison issue without requiring consumers to change their config
