### PR TITLE
fix(modal): make dismiss idempotent when modal is not presented

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -273,13 +273,15 @@ function BottomSheetModalComponent<T = never>(
       }
 
       /**
-       * if the modal position is already in a closed position,
+       * if the modal was never presented or is already in a closed position,
        * then we unmount the node and early exit.
        */
       if (
-        [MODAL_STATUS.CLOSED, MODAL_STATUS.MINIMIZED].includes(
-          statusRef.current
-        ) ||
+        [
+          MODAL_STATUS.INITIAL,
+          MODAL_STATUS.CLOSED,
+          MODAL_STATUS.MINIMIZED,
+        ].includes(statusRef.current) ||
         (statusRef.current === MODAL_STATUS.DISMISSING &&
           currentIndexRef.current === -1)
       ) {


### PR DESCRIPTION
## Motivation

Calling `dismiss()` on a modal whose status is `INITIAL` — never presented, or already self-dismissed and reset — permanently breaks it: every subsequent `present()` silently no-ops. `handleDismiss` falls through the early-exit and sets `statusRef` to `DISMISSING`, nothing ever resets it (no `BottomSheet` is mounted to fire `onClose`), and `handlePortalRender` bails on `DISMISSING` forever after.

This breaks the common declarative wrapper pattern:

```tsx
useEffect(() => {
  if (visible) modalRef.current?.present();
  else modalRef.current?.dismiss();
}, [visible]);
```

A backdrop/swipe close resets the status to `INITIAL`, so the wrapper's next `dismiss()` hits exactly this case.

This PR treats `INITIAL` as already-closed in `handleDismiss`, mirroring `CLOSED`/`MINIMIZED`, so `dismiss()` is idempotent. Full analysis and a Snack repro are in #2669.

Verified in a real app on iOS after upgrading to 5.2.14: with this change, present → user close → `dismiss()` → present cycles work repeatedly.

Fixes #2669

## Before / after

Minimal repro (scripted): `dismiss()` on a never-presented modal, then `present()` twice.

Before — `present()` never works after the initial `dismiss()`:

https://github.com/user-attachments/assets/7d3df54b-d351-41e0-8d34-cc3067dd582a

After — `dismiss()` is a safe no-op and `present()` opens the sheet:

https://github.com/user-attachments/assets/1f5b83c2-159b-42e6-8c4d-1b828c4ce61c
