### PR TITLE
fix(mock): fire onDismiss/onClose callbacks in BottomSheetModal and BottomSheet

### DIFF
--- a/mock.js
+++ b/mock.js
@@ -34,9 +34,11 @@ class BottomSheetModal extends React.Component {
   collapse() {}
   close() {
     this.data = null;
+    this.props?.onClose?.();
   }
   forceClose() {
     this.data = null;
+    this.props?.onClose?.();
   }
   present(data) {
     // Store data passed to present
@@ -46,6 +48,7 @@ class BottomSheetModal extends React.Component {
   }
   dismiss() {
     this.data = null;
+    this.props?.onDismiss?.();
   }
 
   render() {
@@ -61,8 +64,12 @@ class BottomSheet extends React.Component {
   snapToPosition() {}
   expand() {}
   collapse() {}
-  close() {}
-  forceClose() {}
+  close() {
+    this.props?.onClose?.();
+  }
+  forceClose() {
+    this.props?.onClose?.();
+  }
 
   render() {
     return this.props.children;


### PR DESCRIPTION
## Problem

`BottomSheetModal.dismiss()`, `BottomSheetModal.close()`, `BottomSheetModal.forceClose()`, `BottomSheet.close()`, and `BottomSheet.forceClose()` in `mock.js` silently drop their respective `onDismiss`/`onClose` props.

Any component that relies on these callbacks for cleanup — e.g. queued drawer systems that need `onDismiss` to dequeue a sheet — will **silently hang in tests**: the queue entry stays stuck in a `"dismissing"` state and blocks subsequent sheets from opening.

This forces consumers to patch the mock themselves on a per-test basis, which is fragile and obscures the real issue.

## Reproduction

```js
const ref = React.createRef();
const onDismiss = jest.fn();

render(<BottomSheetModal ref={ref} onDismiss={onDismiss} />);
act(() => ref.current.dismiss());

expect(onDismiss).toHaveBeenCalled(); // ❌ fails — onDismiss is never called
```

## Fix

Call `this.props?.onDismiss?.()` in `dismiss()`, and `this.props?.onClose?.()` in `close()` / `forceClose()` for both `BottomSheetModal` and `BottomSheet`.

```diff
  dismiss() {
    this.data = null;
+   this.props?.onDismiss?.();
  }

  close() {
    this.data = null;
+   this.props?.onClose?.();
  }

  forceClose() {
    this.data = null;
+   this.props?.onClose?.();
  }
```