### PR TITLE
fix: evaluate mount position from JS when animated reactions never fire

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1084,6 +1084,46 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         isLayoutCalculated,
       ]
     );
+
+    /**
+     * Ensure the mount position evaluation runs even when the animated
+     * reaction that normally triggers it never fires.
+     *
+     * On Reanimated v4, every `useAnimatedReaction` attached to a component
+     * instance can fail to fire when the instance mounts while the JS thread
+     * is busy: derived values (detents, isLayoutCalculated) still compute
+     * correctly, but the reaction that evaluates the initial position never
+     * runs, leaving the sheet parked off-screen at the container height.
+     *
+     * This effect re-dispatches the same evaluation from the JS side until
+     * the mount has been handled, then stops. When the reactions are healthy
+     * the first check observes `didAnimateOnMount` already true and does
+     * nothing.
+     */
+    useEffect(() => {
+      let attempts = 0;
+      const enforceMountPosition = setInterval(() => {
+        if (didAnimateOnMount.value || attempts >= 20) {
+          clearInterval(enforceMountPosition);
+          return;
+        }
+        attempts += 1;
+        runOnUI(() => {
+          'worklet';
+          if (didAnimateOnMount.value) {
+            return;
+          }
+          if (
+            animatedAnimationState.get().status === ANIMATION_STATUS.RUNNING
+          ) {
+            return;
+          }
+          evaluatePosition(ANIMATION_SOURCE.MOUNT);
+        })();
+      }, 100);
+      return () => clearInterval(enforceMountPosition);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
     //#endregion
 
     //#region public methods
@@ -1811,6 +1851,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
               containerLayoutState={containerLayoutState}
               topInset={topInset}
               bottomInset={bottomInset}
+              modal={$modal}
               detached={detached}
               style={_providedContainerStyle}
             >

--- a/src/components/bottomSheetHostingContainer/BottomSheetHostingContainer.tsx
+++ b/src/components/bottomSheetHostingContainer/BottomSheetHostingContainer.tsx
@@ -17,6 +17,7 @@ function BottomSheetHostingContainerComponent({
   layoutState,
   topInset = 0,
   bottomInset = 0,
+  modal,
   shouldCalculateHeight = true,
   detached,
   style,
@@ -61,6 +62,9 @@ function BottomSheetHostingContainerComponent({
         layoutState.modify(state => {
           'worklet';
           state.rawContainerHeight = height;
+          state.containerHeight = modal
+            ? height - topInset - bottomInset
+            : height;
           return state;
         });
       }
@@ -108,7 +112,7 @@ function BottomSheetHostingContainerComponent({
         });
       }
     },
-    [layoutState, containerLayoutState]
+    [layoutState, containerLayoutState, modal, topInset, bottomInset]
   );
   //#endregion
 

--- a/src/components/bottomSheetHostingContainer/types.d.ts
+++ b/src/components/bottomSheetHostingContainer/types.d.ts
@@ -10,6 +10,7 @@ export interface BottomSheetHostingContainerProps
   > {
   containerLayoutState?: SharedValue<ContainerLayoutState>;
   layoutState?: SharedValue<LayoutState>;
+  modal?: boolean;
 
   shouldCalculateHeight?: boolean;
   style?: StyleProp<ViewStyle>;


### PR DESCRIPTION
## Motivation

Fixes #2721 (and the stale-closed #2690; an earlier report #2719 was auto-closed for not following the issue form): on Reanimated 4, **every** `useAnimatedReaction` attached to a sheet instance can fail to register when the instance mounts while the JS thread is busy. Derived values (detents, `isLayoutCalculated`) still compute, but the reaction that runs the mount position evaluation never fires — the sheet mounts parked off-screen at container height, `onChange` never fires, and provided `animatedIndex`/`animatedPosition` values are never written. Reproduced in production on mid-tier Android (details and Sentry field evidence in #2719).

## Changes

**1. Seed `containerHeight` at the point of measurement** (`BottomSheetHostingContainer`): write `containerHeight` alongside `rawContainerHeight` in the same `layoutState.modify`, so initial layout state doesn't depend on the raw→container reaction firing. This incorporates #2689 — credit to @christian-apollo; happy to rebase if that lands first. `verticalInset` handling matches the reaction it replaces (modal subtracts insets, non-modal doesn't; modals pass `shouldCalculateHeight={false}` so in practice this path serves non-modal sheets).

**2. JS-driven mount evaluation fallback** (`BottomSheet`): a mount effect re-dispatches `evaluatePosition(ANIMATION_SOURCE.MOUNT)` via `runOnUI` every 100ms (max 20 attempts) until `didAnimateOnMount` flips, skipping while an animation is already `RUNNING` (so keyboard/mount animations are never interrupted). It runs the exact evaluation the reaction would have run — same guards, same branches — so semantics are unchanged. When reactions are healthy, the first check observes `didAnimateOnMount === true` and the effect retires without dispatching anything.

Both parts are needed: without (1), `evaluatePosition`/`snapToIndex` early-exit on "layout not ready" forever; without (2), the sheet still mounts invisible with perfectly correct layout state because nothing ever *moves* it.

## Behavior when healthy

- Reactions registered fine → first interval tick sees `didAnimateOnMount` true → cleanup, zero UI dispatches.
- `animateOnMount` (mount animation running) → `RUNNING` guard skips until it completes, then `didAnimateOnMount` is true → no-op.
- Sheets mounted closed (`index={-1}`) → evaluation resolves the closed position exactly as the reaction path would.

## Testing

Shipped as a patch-package in production (Android-heavy language-learning app): the mount-invisible reports stopped; an independent `measureInWindow`-based watchdog we run alongside confirms sheets now position on mount even on the devices that previously reproduced it.

