### PR TITLE
fix: restore BottomSheetModal generic default to any

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -32,9 +32,11 @@ const INITIAL_STATE: BottomSheetModalState = {
   data: undefined,
 };
 
-type BottomSheetModal<T = never> = BottomSheetModalMethods<T>;
+// biome-ignore lint/suspicious/noExplicitAny: Using 'any' allows users to define their own strict types for 'data' property.
+type BottomSheetModal<T = any> = BottomSheetModalMethods<T>;
 
-function BottomSheetModalComponent<T = never>(
+// biome-ignore lint/suspicious/noExplicitAny: Using 'any' allows users to define their own strict types for 'data' property.
+function BottomSheetModalComponent<T = any>(
   props: BottomSheetModalProps<T>,
   ref: React.ForwardedRef<BottomSheetModal<T>>
 ) {
@@ -565,7 +567,8 @@ function BottomSheetModalComponent<T = never>(
 }
 
 const BottomSheetModal = memo(forwardRef(BottomSheetModalComponent)) as <
-  T = never,
+  // biome-ignore lint/suspicious/noExplicitAny: Using 'any' allows users to define their own strict types for 'data' property.
+  T = any,
 >(
   props: BottomSheetModalProps<T> & {
     ref?: React.ForwardedRef<BottomSheetModal<T>>;


### PR DESCRIPTION
## Summary
The generic default on the internal `BottomSheetModal` type alias was accidentally changed from `T = any` to `T = never` in cfbe558 ("chore: updated biome and formatted the code", released in 5.2.9). That commit removed the `biome-ignore` comments suppressing `noExplicitAny`, and the default was switched to `never` to satisfy the lint rule instead of restoring the ignore.

Since this type isn't exported from the package's public entry point, the documented bare-ref pattern (`useRef<BottomSheetModal>(null)`) now resolves to `BottomSheetModalMethods<never>` instead of `<any>`, breaking under strict TypeScript.

## Test plan
- [x] `yarn typescript` passes
- [x] `yarn lint` passes (no new warnings vs master)
- [x] Verified against a real-world app using the documented Modal example, under `strict: true`