### PR TITLE
fix: capture window dimensions in layout worklet

### DIFF
--- a/src/hooks/useAnimatedLayout.ts
+++ b/src/hooks/useAnimatedLayout.ts
@@ -106,13 +106,18 @@ export function useAnimatedLayout(
     [state, verticalInset, modal]
   );
   useEffect(() => {
-    Dimensions.addEventListener('change', ({ window }) => {
-      state.modify(_state => {
-        'worklet';
-        _state.window = window;
-        return _state;
-      });
-    });
+    const subscription = Dimensions.addEventListener(
+      'change',
+      ({ window: windowDimensions }) => {
+        state.modify(_state => {
+          'worklet';
+          _state.window = windowDimensions;
+          return _state;
+        });
+      }
+    );
+
+    return () => subscription.remove();
   }, [state]);
   //#endregion
 


### PR DESCRIPTION
## Motivation

Since v5.2.14, the `Dimensions` listener in `useAnimatedLayout` destructures its payload into a local named `window`. Reanimated treats `window` as an ambient default global, so it does not capture that binding in the `state.modify` worklet closure. Native UI runtimes have no global `window`, and every dimensions change can therefore throw `ReferenceError: Property 'window' doesn't exist`.

This renames the binding to `windowDimensions`, which Reanimated captures, and removes the Dimensions subscription when the hook unmounts so repeated sheet mounts do not accumulate listeners.

Closes #2734

## Verification

- RED Babel/Reanimated 3.19.1 transform of the previous callback produced `__closure = {}` while its worklet body referenced `window`.
- GREEN transform of the committed file produces `__closure = { windowDimensions: windowDimensions }` and includes `subscription.remove()` cleanup.
- `yarn typescript`
- `yarn build`
- `yarn biome check --error-on-warnings src/hooks/useAnimatedLayout.ts`
- Full `yarn lint` reaches one pre-existing warning in `src/hooks/useBoundingClientRect.ts:54`; the changed file is clean.