### PR TITLE
fix: preserve content when toggling panning gesture

### DIFF
--- a/src/components/bottomSheet/BottomSheetContent.tsx
+++ b/src/components/bottomSheet/BottomSheetContent.tsx
@@ -1,6 +1,6 @@
 import React, { memo, useMemo } from 'react';
 import type { ViewProps, ViewStyle } from 'react-native';
-import Animated, {
+import {
   type AnimatedStyle,
   useAnimatedStyle,
   useDerivedValue,
@@ -44,7 +44,6 @@ function BottomSheetContentComponent({
   const {
     enableDynamicSizing,
     overDragResistanceFactor,
-    enableContentPanningGesture,
     animatedPosition,
     animatedLayoutState,
     animatedDetentsState,
@@ -233,11 +232,8 @@ function BottomSheetContentComponent({
   //#endregion
 
   //#region render
-  const DraggableView = enableContentPanningGesture
-    ? BottomSheetDraggableView
-    : Animated.View;
   return (
-    <DraggableView
+    <BottomSheetDraggableView
       accessible={accessible}
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}
@@ -245,7 +241,7 @@ function BottomSheetContentComponent({
       style={contentContainerStyle}
     >
       {children}
-    </DraggableView>
+    </BottomSheetDraggableView>
   );
   //#endregion
 }


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

Changing `enableContentPanningGesture` currently swaps the content wrapper between `BottomSheetDraggableView` and `Animated.View`. Since those are different component types, React unmounts and remounts the entire content subtree when the prop changes.

Keep `BottomSheetDraggableView` as the stable wrapper. It already rebuilds its pan gesture with `.enabled(enableContentPanningGesture)`, so gesture behavior remains dynamic without replacing the content tree.

Closes #2733.

## Verification

- React identity regression harness: content mount count stays at 1 after toggling the prop
- `yarn typescript`
- `yarn build`
- `yarn biome check --error-on-warnings src/components/bottomSheet/BottomSheetContent.tsx`
- `git diff --check`

The repository-wide `yarn lint` still reports the existing unrelated optional-chain warning in `src/hooks/useBoundingClientRect.ts:54`.