### PR TITLE
fix: hide closed sheets below edge-to-edge containers

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -215,7 +215,10 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
     const animatedCurrentIndex = useReactiveSharedValue(
       animateOnMount ? -1 : _providedIndex
     );
-    const animatedPosition = useSharedValue(Dimensions.get('window').height);
+    // Keep the closed sheet below edge-to-edge containers on Android.
+    const animatedPosition = useSharedValue(
+      Dimensions.get(Platform.OS === 'android' ? 'screen' : 'window').height
+    );
 
     // conditional
     const didAnimateOnMount = useSharedValue(


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

## Motivation

Fixes #2747.

On Android edge-to-edge devices, `Dimensions.get('window').height` can exclude system bars while the measured sheet container spans the full screen. A sheet mounted permanently at `index={-1}` can therefore start above its real closed detent and leave its handle visible.

Initialize the Android position from `screen.height`, which stays at or below the full-screen container edge. Keep the existing `window.height` behavior on iOS and web so their mount-animation starting point is unchanged.

## Verification

- RED invariant harness against `master`: failed while the initial position used `window.height`
- GREEN invariant harness: Android selects `screen.height`, other platforms select `window.height`
- `yarn typescript`
- `yarn build`
- `yarn biome check --error-on-warnings src/components/bottomSheet/BottomSheet.tsx`
- `git diff --check`

Repository-wide `yarn lint` still reports the existing unrelated optional-chain warning in `src/hooks/useBoundingClientRect.ts:54`; the changed file is clean.

I could not run the hardware-specific Samsung edge-to-edge reproduction locally. The patch matches the measured `window < container == screen` geometry and keeps the non-Android path unchanged.
