### PR TITLE
fix: isolate modal provider layout state

### DIFF
--- a/src/components/bottomSheetModalProvider/BottomSheetModalProvider.tsx
+++ b/src/components/bottomSheetModalProvider/BottomSheetModalProvider.tsx
@@ -26,9 +26,10 @@ const BottomSheetModalProviderWrapper = ({
   children,
 }: BottomSheetModalProviderProps) => {
   //#region layout variables
-  const animatedContainerLayoutState = useSharedValue<ContainerLayoutState>(
-    INITIAL_CONTAINER_LAYOUT
-  );
+  const animatedContainerLayoutState = useSharedValue<ContainerLayoutState>({
+    ...INITIAL_CONTAINER_LAYOUT,
+    offset: { ...INITIAL_CONTAINER_LAYOUT.offset },
+  });
   //#endregion
 
   //#region variables


### PR DESCRIPTION
## Motivation

Multiple `BottomSheetModalProvider` instances currently pass the same module-level `INITIAL_CONTAINER_LAYOUT` object into `useSharedValue`. Since hosting-container updates mutate that object through `.modify()`, a nested provider can overwrite the root provider's height and offset, causing later root sheets to dismiss toward the nested container's shorter boundary.

This change gives each provider a fresh layout object and a separately cloned mutable `offset`. It preserves the existing values and shared-value API while preventing layout measurements from leaking across providers.

Fixes #2729.

### Verification

- Confirmed immediately before pushing that no other open PR references #2729.
- TDD AST probe failed on `master` because `useSharedValue` received the module singleton directly, then passed after the outer object and nested offset were cloned.
- `yarn typescript` passed.
- `yarn build` passed for CommonJS, ESM, and TypeScript declarations; both JavaScript outputs contain the nested clone.
- `yarn biome check --error-on-warnings src/components/bottomSheetModalProvider/BottomSheetModalProvider.tsx` passed.
- The repository pre-commit Biome checks and commitlint passed.
- Full `yarn lint` remains blocked by the existing optional-chain warning in `src/hooks/useBoundingClientRect.ts:54`, outside this diff.

The repository currently has no unit-test files or `test` script, so no persistent Jest suite was available. I did not run the nested iOS page-sheet reproduction on a device; runtime UI verification remains outstanding.
