### PR TITLE
fix: complete web pan-down close lifecycle

### DIFF
--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -607,26 +607,6 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           return;
         }
 
-        if (position === animatedPosition.get()) {
-          return;
-        }
-
-        // early exit if there is a running animation to
-        // the same position
-        const { status: animationStatus, nextPosition } =
-          animatedAnimationState.get();
-        if (
-          animationStatus === ANIMATION_STATUS.RUNNING &&
-          position === nextPosition
-        ) {
-          return;
-        }
-
-        // stop animation if it is running
-        if (animationStatus === ANIMATION_STATUS.RUNNING) {
-          stopAnimation();
-        }
-
         /**
          * offset the position if keyboard is shown and behavior not extend.
          */
@@ -666,6 +646,34 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
           }
         }
 
+        const isSamePosition = position === animatedPosition.get();
+        const shouldSettleGestureClose =
+          isSamePosition &&
+          source === ANIMATION_SOURCE.GESTURE &&
+          position === closedDetentPosition &&
+          index !== animatedCurrentIndex.get();
+
+        if (isSamePosition && !shouldSettleGestureClose) {
+          return;
+        }
+
+        // early exit if there is a running animation to
+        // the same position
+        const { status: animationStatus, nextPosition } =
+          animatedAnimationState.get();
+        if (
+          !isSamePosition &&
+          animationStatus === ANIMATION_STATUS.RUNNING &&
+          position === nextPosition
+        ) {
+          return;
+        }
+
+        // stop animation if it is running
+        if (animationStatus === ANIMATION_STATUS.RUNNING) {
+          stopAnimation();
+        }
+
         /**
          * set the animation state
          */
@@ -684,6 +692,16 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
          * fire `onAnimate` callback
          */
         runOnJS(handleOnAnimate)(index, position);
+
+        /**
+         * A web gesture can already move the sheet to the closed position
+         * before its end event is handled. In that case, settle the pending
+         * index transition so the close lifecycle still completes.
+         */
+        if (shouldSettleGestureClose) {
+          animateToPositionCompleted(true);
+          return;
+        }
 
         /**
          * start animation
@@ -705,6 +723,7 @@ const BottomSheetComponent = forwardRef<BottomSheet, BottomSheetProps>(
         _providedOverrideReduceMotion,
         animatedDetentsState,
         animatedAnimationState,
+        animatedCurrentIndex,
         animatedKeyboardState,
         animatedPosition,
         animatedSheetState,

--- a/src/hooks/useGestureEventsHandlersDefault.web.tsx
+++ b/src/hooks/useGestureEventsHandlersDefault.web.tsx
@@ -370,7 +370,10 @@ export const useGestureEventsHandlersDefault = () => {
        * if destination point is the same as the current position,
        * then no need to perform animation.
        */
-      if (destinationPoint === animatedPosition.value) {
+      if (
+        destinationPoint === animatedPosition.value &&
+        destinationPoint !== closedDetentPosition
+      ) {
         return;
       }
 


### PR DESCRIPTION
## Motivation\n\nA fast downward pan in Safari Web can move the sheet to its closed detent before the gesture end handler runs. Both the web handler and the shared animator then treated the equal target/current position as a no-op, so the modal became visually hidden without emitting onChange(-1), onClose, or onDismiss.\n\n## Changes\n\n- forward an already-reached closed detent from the web gesture end handler\n- settle a gesture-driven close when the pixel position is already reached but the current index is not -1\n- reuse the existing animation completion path so onAnimate, onChange, and onClose retain their normal order\n- preserve no-op behavior for duplicate closes and ordinary same-position operations\n\nFixes #2749\n\n## Verification\n\n- yarn typescript\n- focused Biome lint on both changed files\n- yarn build\n- git diff --check\n- deterministic state-transition probe: original path drops all close callbacks; fixed path emits one onAnimate/onChange/onClose, suppresses duplicate close, and cancels a conflicting animation\n\nThe repository-wide yarn lint currently fails on an existing warning in src/hooks/useBoundingClientRect.ts; neither this PR nor the focused lint touches that file.\n\nA Safari/WebKit runtime pass was not available locally because the checked-in example/package-lock.json is stale relative to example/package.json, so npm ci cannot construct the owner example without rewriting its lockfile. The issue Snack remains the browser reproduction.