### PR TITLE
fix: omit native scroll handler dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://gorhom.dev/react-native-bottom-sheet/",
   "scripts": {
     "typescript": "tsc --skipLibCheck --noEmit",
+    "test": "node --test",
     "lint": "biome lint --error-on-warnings ./src",
     "build": "bob build && yarn copy-dts && yarn delete-dts.js && yarn delete-debug-view",
     "copy-dts": "copyfiles -u 1 \"src/**/*.d.ts\" lib/typescript",

--- a/src/hooks/useScrollHandler.ts
+++ b/src/hooks/useScrollHandler.ts
@@ -30,43 +30,31 @@ export const useScrollHandler = (
   } = useScrollEventsHandlers(scrollableRef, scrollableContentOffsetY);
 
   // callbacks
-  const scrollHandler = useAnimatedScrollHandler(
-    {
-      onScroll: (event, context) => {
-        handleOnScroll(event, context);
+  const scrollHandler = useAnimatedScrollHandler({
+    onScroll: (event, context) => {
+      handleOnScroll(event, context);
 
-        if (onScroll) {
-          runOnJS(onScroll)({ nativeEvent: event });
-        }
-      },
-      onBeginDrag: (event, context) => {
-        handleOnBeginDrag(event, context);
-
-        if (onScrollBeginDrag) {
-          runOnJS(onScrollBeginDrag)({ nativeEvent: event });
-        }
-      },
-      onEndDrag: (event, context) => {
-        handleOnEndDrag(event, context);
-
-        if (onScrollEndDrag) {
-          runOnJS(onScrollEndDrag)({ nativeEvent: event });
-        }
-      },
-      onMomentumBegin: handleOnMomentumBegin,
-      onMomentumEnd: handleOnMomentumEnd,
+      if (onScroll) {
+        runOnJS(onScroll)({ nativeEvent: event });
+      }
     },
-    [
-      handleOnScroll,
-      handleOnBeginDrag,
-      handleOnEndDrag,
-      handleOnMomentumBegin,
-      handleOnMomentumEnd,
-      onScroll,
-      onScrollBeginDrag,
-      onScrollEndDrag,
-    ]
-  );
+    onBeginDrag: (event, context) => {
+      handleOnBeginDrag(event, context);
+
+      if (onScrollBeginDrag) {
+        runOnJS(onScrollBeginDrag)({ nativeEvent: event });
+      }
+    },
+    onEndDrag: (event, context) => {
+      handleOnEndDrag(event, context);
+
+      if (onScrollEndDrag) {
+        runOnJS(onScrollEndDrag)({ nativeEvent: event });
+      }
+    },
+    onMomentumBegin: handleOnMomentumBegin,
+    onMomentumEnd: handleOnMomentumEnd,
+  });
 
   return { scrollHandler, scrollableRef, scrollableContentOffsetY };
 };

--- a/tests/useScrollHandler.test.mjs
+++ b/tests/useScrollHandler.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import ts from 'typescript';
+
+const nativeSource = readFileSync(
+  new URL('../src/hooks/useScrollHandler.ts', import.meta.url),
+  'utf8'
+);
+
+const sourceFile = ts.createSourceFile(
+  'useScrollHandler.ts',
+  nativeSource,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TS
+);
+
+test('native scroll handlers omit web-only dependency arrays', () => {
+  const argumentCounts = [];
+
+  const visit = node => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'useAnimatedScrollHandler'
+    ) {
+      argumentCounts.push(node.arguments.length);
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+
+  assert.deepEqual(argumentCounts, [1]);
+});


### PR DESCRIPTION
## Motivation

Fixes #2758.

Reanimated 4.6 warns whenever native `useAnimatedScrollHandler` receives a dependency array because that argument is only intended for web builds without the Worklets Babel plugin. Bottom Sheet already resolves `useScrollHandler.web.ts` on web, so `useScrollHandler.ts` is the native implementation and does not need the second argument.

This removes only the native dependency array. The handler closures and existing platform-specific web implementation remain unchanged.

## Verification

- TDD regression: the TypeScript-AST contract test failed with native argument count `2`, then passed with `1`
- `yarn test` — 1 passed
- `yarn typescript` — passed
- `yarn build` — CommonJS, module, and declarations passed; built native output calls `useAnimatedScrollHandler` with one argument
- Biome check for all changed files — passed

The repository-wide `yarn lint` command still reports one existing warning in unchanged `src/hooks/useBoundingClientRect.ts:54` (`useOptionalChain`); this PR adds no lint findings.

I intentionally did not migrate the existing `runOnJS` calls here: the package still supports Reanimated 3 and does not declare `react-native-worklets` as a peer, so that compatibility migration is separate from this warning-only fix.