### PR TITLE
fix: prevent locked scroll re-entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://gorhom.dev/react-native-bottom-sheet/",
   "scripts": {
+    "test": "node --test tests/*.test.cjs",
     "typescript": "tsc --skipLibCheck --noEmit",
     "lint": "biome lint --error-on-warnings ./src",
     "build": "bob build && yarn copy-dts && yarn delete-dts.js && yarn delete-debug-view",

--- a/src/hooks/executeWithLock.ts
+++ b/src/hooks/executeWithLock.ts
@@ -1,0 +1,17 @@
+type Lock = {
+  value: boolean;
+};
+
+export function executeWithLock(lock: Lock, operation: () => void) {
+  'worklet';
+  if (lock.value) {
+    return;
+  }
+
+  lock.value = true;
+  try {
+    operation();
+  } finally {
+    lock.value = false;
+  }
+}

--- a/src/hooks/useScrollEventsHandlersDefault.ts
+++ b/src/hooks/useScrollEventsHandlersDefault.ts
@@ -1,11 +1,12 @@
 import { useCallback } from 'react';
 import { State } from 'react-native-gesture-handler';
-import { scrollTo } from 'react-native-reanimated';
+import { scrollTo, useSharedValue } from 'react-native-reanimated';
 import { ANIMATION_STATUS, SCROLLABLE_STATUS, SHEET_STATE } from '../constants';
 import type {
   ScrollEventHandlerCallbackType,
   ScrollEventsHandlersHookType,
 } from '../types';
+import { executeWithLock } from './executeWithLock';
 import { useBottomSheetInternal } from './useBottomSheetInternal';
 
 export type ScrollEventContextType = {
@@ -25,8 +26,19 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
     animatedAnimationState,
     animatedHandleGestureState,
   } = useBottomSheetInternal();
+  const isLocking = useSharedValue(false);
 
   //#region callbacks
+  const lockScrollableTo = useCallback(
+    (position: number) => {
+      'worklet';
+      executeWithLock(isLocking, () => {
+        // @ts-expect-error
+        scrollTo(scrollableRef, 0, position, false);
+      });
+    },
+    [isLocking, scrollableRef]
+  );
   const handleOnScroll: ScrollEventHandlerCallbackType<ScrollEventContextType> =
     useCallback(
       ({ contentOffset: { y } }, context) => {
@@ -55,14 +67,13 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
           const lockPosition = context.shouldLockInitialPosition
             ? (context.initialContentOffsetY ?? 0)
             : 0;
-          // @ts-expect-error
-          scrollTo(scrollableRef, 0, lockPosition, false);
+          lockScrollableTo(lockPosition);
           scrollableContentOffsetY.value = lockPosition;
           return;
         }
       },
       [
-        scrollableRef,
+        lockScrollableTo,
         scrollableContentOffsetY,
         animatedScrollableStatus,
         animatedSheetState,
@@ -104,8 +115,7 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
           const lockPosition = context.shouldLockInitialPosition
             ? (context.initialContentOffsetY ?? 0)
             : 0;
-          // @ts-expect-error
-          scrollTo(scrollableRef, 0, lockPosition, false);
+          lockScrollableTo(lockPosition);
           scrollableContentOffsetY.value = lockPosition;
           return;
         }
@@ -119,7 +129,7 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
         }
       },
       [
-        scrollableRef,
+        lockScrollableTo,
         scrollableContentOffsetY,
         animatedAnimationState,
         animatedScrollableStatus,
@@ -134,8 +144,7 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
           const lockPosition = context.shouldLockInitialPosition
             ? (context.initialContentOffsetY ?? 0)
             : 0;
-          // @ts-expect-error
-          scrollTo(scrollableRef, 0, lockPosition, false);
+          lockScrollableTo(lockPosition);
           scrollableContentOffsetY.value = 0;
           return;
         }
@@ -150,7 +159,7 @@ export const useScrollEventsHandlersDefault: ScrollEventsHandlersHookType = (
       },
       [
         scrollableContentOffsetY,
-        scrollableRef,
+        lockScrollableTo,
         animatedAnimationState,
         animatedScrollableStatus,
         animatedScrollableState,

--- a/tests/executeWithLock.test.cjs
+++ b/tests/executeWithLock.test.cjs
@@ -1,0 +1,56 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const ts = require('typescript');
+
+function loadExecuteWithLock() {
+  const filePath = path.join(
+    __dirname,
+    '..',
+    'src',
+    'hooks',
+    'executeWithLock.ts'
+  );
+  const source = fs.readFileSync(filePath, 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: filePath,
+  });
+  const module = { exports: {} };
+  Function('module', 'exports', outputText)(module, module.exports);
+  return module.exports.executeWithLock;
+}
+
+test('prevents an operation from re-entering while it holds the lock', () => {
+  const executeWithLock = loadExecuteWithLock();
+  const lock = { value: false };
+  let executions = 0;
+
+  executeWithLock(lock, () => {
+    executions += 1;
+    executeWithLock(lock, () => {
+      executions += 1;
+    });
+  });
+
+  assert.equal(executions, 1);
+  assert.equal(lock.value, false);
+});
+
+test('releases the lock after the operation throws', () => {
+  const executeWithLock = loadExecuteWithLock();
+  const lock = { value: false };
+
+  assert.throws(
+    () =>
+      executeWithLock(lock, () => {
+        throw new Error('expected');
+      }),
+    /expected/
+  );
+  assert.equal(lock.value, false);
+});


### PR DESCRIPTION
## Motivation

Fixes #2737.

On iOS Fabric, `scrollTo` may synchronously emit another scroll or momentum-end event. While the scrollable remains `LOCKED`, the default handlers call `scrollTo` again on that same native stack until it overflows.

This change adds one shared-value re-entrancy guard around the three locked-state `scrollTo` call sites. The outer command and existing offset updates are preserved; only nested commands are skipped. The guard is released in `finally` so an error cannot leave the scrollable permanently locked.

## Verification

- `yarn test` — 2/2 regression tests pass (re-entry is bounded; lock is released after errors)
- `yarn typescript` — pass
- `yarn biome check --error-on-warnings package.json src/hooks/executeWithLock.ts src/hooks/useScrollEventsHandlersDefault.ts tests/executeWithLock.test.cjs` — pass
- `yarn build` — pass for CommonJS, module, and TypeScript targets

Full `yarn lint` still reports the existing `useOptionalChain` warning in `src/hooks/useBoundingClientRect.ts:54`; that file is unchanged from `master`.