### PR TITLE
fix(modal): clear a stranded DISMISSING status on present()

### DIFF
--- a/src/components/bottomSheetModal/BottomSheetModal.tsx
+++ b/src/components/bottomSheetModal/BottomSheetModal.tsx
@@ -240,6 +240,34 @@ function BottomSheetModalComponent<T = never>(
         });
       }
 
+      /**
+       * a dismissal that never landed must not outlive a request to present.
+       *
+       * `DISMISSING` has exactly one exit: `handleBottomSheetOnClose`, fired
+       * when the inner sheet's close animation completes. Interrupt that
+       * animation and the status is stranded there for the life of the
+       * instance — and from there the failure is self-sustaining:
+       * `handlePortalRender` returns early on `DISMISSING`, so the inner sheet
+       * is never mounted and `bottomSheetRef` stays `null`, so the only line
+       * that clears the status — inside the callback below, behind
+       * `mount && bottomSheetRef.current` — never runs. The guard that blocks
+       * rendering is what keeps the ref `null`, and the `null` ref is what
+       * preserves the guard. `present()` is then a permanent, silent no-op.
+       *
+       * `handleForceDismiss` can escape through its
+       * `DISMISSING && currentIndexRef === -1` branch, but `handleDismiss` has
+       * no `DISMISSING` branch, and here the index never reached `-1`, so
+       * neither recovers. `statusRef` is a ref, so nothing outside the
+       * component can break the cycle either.
+       *
+       * Calling `present()` is unambiguous intent to SHOW, which supersedes a
+       * dismissal still notionally in flight. A dismissal progressing normally
+       * never reaches this line, because nothing calls `present()` during it.
+       */
+      if (statusRef.current === MODAL_STATUS.DISMISSING) {
+        statusRef.current = MODAL_STATUS.INITIAL;
+      }
+
       requestAnimationFrame(() => {
         if (mount && bottomSheetRef.current) {
           statusRef.current = MODAL_STATUS.ANIMATING;


### PR DESCRIPTION

## Summary

`BottomSheetModal.present()` can become a **permanent, silent no-op** after an ordinary dismissal whose close animation never completes. `statusRef` is stranded at `DISMISSING`, and the failure is self-sustaining — nothing inside or outside the component can recover it.

## Why this is not a duplicate of the other open fixes

There are three open PRs in this area (#2670, #2711, #2725) and several reports (#2669, #2713, #2722, #2723). **All of them start from `statusRef === INITIAL`** — a `dismiss()` on a modal that was never presented or has already been torn down. Every guard they add is an `INITIAL` check.

This path is different: the modal **was** genuinely presented and the `dismiss()` was legitimate, so `statusRef` is `PRESENTED`/`ANIMATING` when `handleDismiss` runs and every `INITIAL` guard is bypassed. It is complementary to #2725 rather than competing with it — that PR covers the two `INITIAL` paths, this covers the dismissal path. They touch different functions and do not conflict.

(It is closest in spirit to the long-open #695, but that is v4 and about `BottomSheet.close()`, not the modal's `statusRef` machinery.)

## The deadlock

1. `handleDismiss` on a presented modal sets `statusRef.current = DISMISSING` and calls `bottomSheetRef.current?.close()`.
2. The close animation is interrupted and never reaches the closed position, so **`handleBottomSheetOnClose` never fires** — and it is the only thing that moves `DISMISSING` → `DISMISSED`.
3. `handlePortalRender` now returns early on `DISMISSING` without calling `render()`, so the inner `<BottomSheet>` is **never mounted** and `bottomSheetRef.current` stays `null`.
4. A later `present()` runs, but its only status write sits behind `if (mount && bottomSheetRef.current)` inside the `requestAnimationFrame` — the ref is `null`, so the status is never cleared.

The cycle closes on itself: **the guard that blocks rendering is what keeps the ref `null`, and the `null` ref is what preserves the guard.** `statusRef` is a ref, so no caller can break it from outside.

Note the asymmetry: `handleForceDismiss` has an escape hatch (`DISMISSING && currentIndexRef.current === -1`), but `handleDismiss` has no `DISMISSING` branch at all, and in this state `currentIndexRef.current !== -1` because the animation never drove the index to `-1`. Calling `dismiss()` again simply re-sets `DISMISSING` and calls `close()` on the null ref.

## The change

```ts
if (statusRef.current === MODAL_STATUS.DISMISSING) {
  statusRef.current = MODAL_STATUS.INITIAL;
}
```

At the top of `handlePresent`, before the `requestAnimationFrame`.

Calling `present()` is unambiguous intent to **show**, and it should supersede a dismissal that is still notionally in flight. Clearing the status here breaks the cycle at its one reachable link: the portal renders, the inner sheet mounts, and the normal path resumes. A dismissal progressing normally never reaches this line, because nothing calls `present()` during it.

`INITIAL` rather than a direct jump to `ANIMATING`, so the existing code below stays the single owner of the presented-state transition.

## Verification

- `biome check` clean on the touched file.
- **No unit test.** The repository has no test harness (no jest config, no test script, no test files), so there is nowhere to put a regression test. Happy to add one alongside a test setup if you would like that as a separate PR.
- Behaviourally verified by shipping exactly this change via `patch-package` against `5.2.14` in a production React Native app (0.82.1, React 19, New Architecture/Fabric, Hermes, reanimated 4), on an iPhone 17 Pro simulator running iOS 26.5. The wedge reproduced reliably before the patch and, after it, ~37 minutes of continuous automated stress at faster-than-human pace produced zero recurrences.

The user-visible symptom this fixes: a button that stops working with no error, no warning and no crash, permanently, while an adjacent sheet on the same screen keeps working.

---

<sub>I filed this first as an issue (#2762), but it was auto-closed and locked by the template bot: the bug report template requires an Expo Snack reproduction, and this is a race on the close animation rather than something a fixed script reproduces. Everything from that report is inlined above, so this PR is self-contained. If you would prefer a conforming issue anyway, say so and I will work up a Snack that reproduces it.</sub>
